### PR TITLE
Add validate() function (v0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,43 @@ stdout, stderr = (
 )
 ```
 
+### Validate a media file
+
+`validate()` checks whether a file is valid media without parsing full probe output.
+It returns a `(ok, stderr)` tuple instead of raising on bad media.
+
+```python
+ok, stderr = ffmpeg.validate("video.mkv")
+if not ok:
+    print(f"Invalid media: {stderr}")
+```
+
+The default `loglevel="warning"` surfaces ffprobe warnings (non-monotonic DTS,
+unsupported codecs, truncated frames) in addition to hard errors. Use a stricter
+level when only fatal problems matter:
+
+```python
+ok, stderr = ffmpeg.validate("video.mkv", loglevel="error")
+ok, stderr = ffmpeg.validate("video.mkv", loglevel="fatal")
+```
+
+Pass extra ffprobe flags via `extra_args`:
+
+```python
+ok, stderr = ffmpeg.validate("video.mkv", extra_args=("-hide_banner",))
+```
+
+Use `validate()` when you only need a pass/fail check. Use `probe()` when you need
+stream and format metadata. The only exception `validate()` raises is `FFmpegError`
+when the ffprobe executable could not be run (missing, not executable, etc.).
+
+```python
+try:
+    ok, stderr = ffmpeg.validate("video.mkv")
+except ffmpeg.FFmpegError:
+    print("ffprobe could not be executed")
+```
+
 ### Error handling
 
 ```python
@@ -99,6 +136,8 @@ except ffmpeg.FFmpegError as e:
 ```python
 result = ffmpeg.probe("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
 
+ok, stderr = ffmpeg.validate("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
+
 ffmpeg.input("input.mkv", ffmpeg_path="/usr/local/bin/ffmpeg").output("output.mp4").run()
 ```
 
@@ -112,6 +151,17 @@ Run ffprobe on a file and return a typed `ProbeResult`.
 - `ffprobe_path` -- Path to the ffprobe executable. Defaults to `"ffprobe"`.
 - Returns: `ProbeResult` with `streams` and `format` fields.
 - Raises: `FFmpegError` on subprocess failure or invalid output.
+
+### validate(filename, ffprobe_path="ffprobe", loglevel="warning", extra_args=())
+
+Run ffprobe in validation mode and check for errors/warnings.
+
+- `filename` -- Path to the media file (str or PathLike).
+- `ffprobe_path` -- Path to the ffprobe executable. Defaults to `"ffprobe"`.
+- `loglevel` -- Value passed to ffprobe's `-v` flag. Defaults to `"warning"` (surfaces DTS/codec warnings). Use `"error"` to ignore warnings or `"fatal"`/`"panic"` for only unrecoverable failures.
+- `extra_args` -- Additional raw arguments forwarded to ffprobe before the filename, e.g. `("-hide_banner",)`.
+- Returns: `tuple[bool, str]` -- `(ok, stderr_text)`. `ok` is `True` when ffprobe exits with code 0 and stderr is empty after stripping whitespace.
+- Raises: `FFmpegError` only when the ffprobe executable could not be run. Does not raise on invalid media.
 
 ### input(filename, ffmpeg_path="ffmpeg", **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-wrap"
-version = "0.1.0"
+version = "0.2.0"
 description = "Typed fluent FFmpeg/ffprobe wrapper with msgspec models"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ffmpeg_wrap/__init__.py
+++ b/src/ffmpeg_wrap/__init__.py
@@ -2,7 +2,7 @@ from importlib.metadata import version
 
 from ._builder import FFmpeg, input
 from ._errors import FFmpegError
-from ._probe import Format, ProbeResult, Stream, probe
+from ._probe import Format, ProbeResult, Stream, probe, validate
 
 __version__ = version("ffmpeg-wrap")
 
@@ -14,4 +14,5 @@ __all__ = [
     "Stream",
     "input",
     "probe",
+    "validate",
 ]

--- a/src/ffmpeg_wrap/_builder.py
+++ b/src/ffmpeg_wrap/_builder.py
@@ -130,9 +130,9 @@ class FFmpeg:
             err_msg = e.stderr.decode("utf-8", errors="replace") if e.stderr else str(e)
             logger.error(f"FFmpeg command failed: {err_msg}")
             raise FFmpegError(f"ffmpeg error: {err_msg}") from e
-        except FileNotFoundError as e:
-            logger.error(f"FFmpeg executable not found: {e}")
-            raise FFmpegError(f"ffmpeg not found: {e}") from e
+        except OSError as e:
+            logger.error(f"ffmpeg could not be executed: {e}")
+            raise FFmpegError(f"ffmpeg could not be executed: {e}") from e
 
 
 def _convert_arg(key: str, value: Any) -> list[str]:

--- a/src/ffmpeg_wrap/_probe.py
+++ b/src/ffmpeg_wrap/_probe.py
@@ -9,6 +9,8 @@ from ._errors import FFmpegError
 
 logger = logging.getLogger("ffmpeg_wrap")
 
+_FFPROBE_LOGLEVELS = frozenset({"quiet", "panic", "fatal", "error", "warning", "info", "verbose", "debug", "trace"})
+
 # Known ffmpeg protocols that use "name:" or "name:arg" syntax (no "://").
 # Kept as a whitelist to avoid matching POSIX filenames containing colons.
 _FFMPEG_SIMPLE_PROTOCOLS = frozenset(
@@ -57,6 +59,20 @@ def _is_special_input(filename: str) -> bool:
     return False
 
 
+def _resolve_input(filename: str | os.PathLike[str]) -> str:
+    """Resolve a filename argument to the string passed to ffprobe/ffmpeg.
+
+    PathLike objects are always treated as filesystem paths and resolved to
+    absolute form.  Plain strings are checked for ffmpeg special-input syntax
+    (protocols, pipe:, URLs, "-") and passed through unchanged when detected;
+    otherwise they are resolved as filesystem paths.
+    """
+    filename_str = os.fsdecode(filename)
+    if isinstance(filename, os.PathLike) or not _is_special_input(filename_str):
+        return str(Path(filename_str).resolve())
+    return filename_str
+
+
 class Stream(msgspec.Struct):
     """A single stream from ffprobe output."""
 
@@ -96,6 +112,50 @@ class ProbeResult(msgspec.Struct):
     format: Format | None = None
 
 
+def validate(
+    filename: str | os.PathLike[str],
+    ffprobe_path: str = "ffprobe",
+    loglevel: str = "warning",
+    extra_args: tuple[str, ...] = (),
+) -> tuple[bool, str]:
+    """Run ffprobe in validation mode and report diagnostics.
+
+    Args:
+        filename: Path to the media file (str or PathLike).
+        ffprobe_path: Path to the ffprobe executable.
+        loglevel: Value passed to ffprobe's ``-v`` flag. Defaults to
+            ``"warning"`` so DTS/codec warnings surface in stderr.
+            Use ``"error"`` for a stricter check that ignores warnings,
+            ``"fatal"``/``"panic"`` for only unrecoverable failures,
+            or any other ffprobe loglevel keyword. See ``ffprobe -loglevel help``.
+        extra_args: Additional raw arguments forwarded to ffprobe before the
+            filename, e.g. ``("-show_format",)``. Use with care; no validation
+            is performed on these args.
+
+    Returns:
+        (ok, stderr_text). ok is True iff ffprobe exit code == 0 AND
+        stderr.strip() is empty. stderr_text is the raw decoded stderr
+        (never None, possibly empty string).
+
+    Does NOT raise on bad media — that is a normal outcome for a validator.
+    Raises FFmpegError only when the ffprobe executable cannot be run.
+    Raises ValueError on invalid loglevel.
+    """
+    if loglevel not in _FFPROBE_LOGLEVELS:
+        msg = f"invalid loglevel {loglevel!r}, must be one of: {', '.join(sorted(_FFPROBE_LOGLEVELS))}"
+        raise ValueError(msg)
+    filename_str = _resolve_input(filename)
+    cmd = [ffprobe_path, "-v", loglevel, *[str(a) for a in extra_args], filename_str]
+    try:
+        result = subprocess.run(cmd, capture_output=True, check=False, text=False)
+    except OSError as e:
+        logger.error(f"ffprobe could not be executed: {e}")
+        raise FFmpegError(f"ffprobe could not be executed: {e}") from e
+    stderr_text = result.stderr.decode("utf-8", errors="replace")
+    ok = result.returncode == 0 and not stderr_text.strip()
+    return (ok, stderr_text)
+
+
 def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> ProbeResult:
     """Run ffprobe on the specified file and return typed output.
 
@@ -109,10 +169,7 @@ def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> Pr
     Raises:
         FFmpegError: If ffprobe fails or output cannot be parsed.
     """
-    filename_str = os.fsdecode(filename)
-    # PathLike objects are always filesystem paths; only check special input for bare strings
-    if isinstance(filename, os.PathLike) or not _is_special_input(filename_str):
-        filename_str = str(Path(filename_str).resolve())
+    filename_str = _resolve_input(filename)
 
     cmd = [
         ffprobe_path,
@@ -136,9 +193,9 @@ def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> Pr
         err_msg = e.stderr.decode("utf-8", errors="replace") if e.stderr else str(e)
         logger.error(f"ffprobe failed: {err_msg}")
         raise FFmpegError(f"ffprobe error: {err_msg}") from e
-    except FileNotFoundError as e:
-        logger.error(f"ffprobe executable not found: {e}")
-        raise FFmpegError(f"ffprobe not found: {e}") from e
+    except OSError as e:
+        logger.error(f"ffprobe could not be executed: {e}")
+        raise FFmpegError(f"ffprobe could not be executed: {e}") from e
     except (msgspec.DecodeError, msgspec.ValidationError) as e:
         logger.error(f"Failed to parse ffprobe output: {e}")
         raise FFmpegError(f"ffprobe output parsing error: {e}") from e

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -206,7 +206,7 @@ class TestRun:
         mock_run.side_effect = FileNotFoundError("No such file or directory: 'ffmpeg'")
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4")
-        with pytest.raises(FFmpegError, match="ffmpeg not found"):
+        with pytest.raises(FFmpegError, match="ffmpeg could not be executed"):
             ff.run()
 
     @patch("ffmpeg_wrap._builder.subprocess.run")
@@ -214,7 +214,15 @@ class TestRun:
         mock_run.side_effect = FileNotFoundError("No such file or directory: '/bad/path/ffmpeg'")
         ff = FFmpeg(ffmpeg_path="/bad/path/ffmpeg")
         ff.input("in.mkv").output("out.mp4")
-        with pytest.raises(FFmpegError, match="ffmpeg not found"):
+        with pytest.raises(FFmpegError, match="ffmpeg could not be executed"):
+            ff.run()
+
+    @patch("ffmpeg_wrap._builder.subprocess.run")
+    def test_run_raises_ffmpeg_error_on_permission_error(self, mock_run):
+        mock_run.side_effect = PermissionError("[Errno 13] Permission denied: '/usr/bin/ffmpeg'")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with pytest.raises(FFmpegError, match="ffmpeg could not be executed"):
             ff.run()
 
 

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import subprocess
 from pathlib import Path
@@ -7,7 +8,48 @@ import msgspec
 import pytest
 
 from ffmpeg_wrap._errors import FFmpegError
-from ffmpeg_wrap._probe import Format, ProbeResult, Stream, probe
+from ffmpeg_wrap._probe import Format, ProbeResult, Stream, _resolve_input, probe, validate
+
+
+class TestResolveInput:
+    def test_regular_string_path(self):
+        result = _resolve_input("video.mkv")
+        assert result == str(Path("video.mkv").resolve())
+
+    def test_path_object(self):
+        result = _resolve_input(Path("video.mkv"))
+        assert result == str(Path("video.mkv").resolve())
+
+    def test_pipe_protocol(self):
+        assert _resolve_input("pipe:") == "pipe:"
+        assert _resolve_input("pipe:0") == "pipe:0"
+
+    def test_url(self):
+        assert _resolve_input("http://example.com/video.mp4") == "http://example.com/video.mp4"
+        assert _resolve_input("rtmp://stream.example.com/live") == "rtmp://stream.example.com/live"
+
+    def test_bytes_pathlike(self):
+        class BytesPath(os.PathLike):
+            def __fspath__(self):
+                return b"video.mkv"
+
+        result = _resolve_input(BytesPath())
+        assert result == str(Path("video.mkv").resolve())
+
+    def test_protocol_looking_filename_md5(self):
+        result = _resolve_input("md5:clip.mkv")
+        assert result == str(Path("md5:clip.mkv").resolve())
+
+    def test_protocol_looking_filename_tee(self):
+        result = _resolve_input("tee:output.mkv")
+        assert result == str(Path("tee:output.mkv").resolve())
+
+    def test_dash_stdin(self):
+        assert _resolve_input("-") == "-"
+
+    def test_posix_colon_in_filename(self):
+        result = _resolve_input("foo:bar.mkv")
+        assert result == str(Path("foo:bar.mkv").resolve())
 
 
 class TestStream:
@@ -385,5 +427,168 @@ class TestProbeFunction:
     @patch("ffmpeg_wrap._probe.subprocess.run")
     def test_probe_raises_ffmpeg_error_on_missing_binary(self, mock_run):
         mock_run.side_effect = FileNotFoundError("No such file or directory: 'ffprobe'")
-        with pytest.raises(FFmpegError, match="ffprobe not found"):
+        with pytest.raises(FFmpegError, match="ffprobe could not be executed"):
             probe("video.mkv")
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_probe_raises_ffmpeg_error_on_permission_error(self, mock_run):
+        mock_run.side_effect = PermissionError("[Errno 13] Permission denied: '/usr/bin/ffprobe'")
+        with pytest.raises(FFmpegError, match="ffprobe could not be executed"):
+            probe("video.mkv")
+
+
+class TestValidate:
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_returns_true_on_clean_file(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        ok, stderr = validate("video.mkv")
+        assert ok is True
+        assert stderr == ""
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_returns_false_on_nonzero_exit(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"", stderr=b"moov atom not found"
+        )
+        ok, stderr = validate("broken.mkv")
+        assert ok is False
+        assert stderr == "moov atom not found"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_returns_false_on_warnings_with_zero_exit(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=b"", stderr=b"non-monotonic DTS"
+        )
+        ok, stderr = validate("warning.mkv")
+        assert ok is False
+        assert stderr == "non-monotonic DTS"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_returns_false_on_nonexistent_file(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1, stdout=b"", stderr=b"No such file")
+        ok, stderr = validate("/nonexistent/file.mkv")
+        assert ok is False
+        assert stderr == "No such file"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_raises_on_missing_binary(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("No such file or directory: 'ffprobe'")
+        with pytest.raises(FFmpegError, match="ffprobe could not be executed"):
+            validate("video.mkv")
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_builds_correct_command(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("video.mkv")
+        cmd = mock_run.call_args[0][0]
+        resolved = str(Path("video.mkv").resolve())
+        assert cmd == ["ffprobe", "-v", "warning", resolved]
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_custom_loglevel(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("video.mkv", loglevel="error")
+        cmd = mock_run.call_args[0][0]
+        resolved = str(Path("video.mkv").resolve())
+        assert cmd == ["ffprobe", "-v", "error", resolved]
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_extra_args_forwarded_before_filename(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("video.mkv", loglevel="error", extra_args=("-show_format", "-hide_banner"))
+        cmd = mock_run.call_args[0][0]
+        resolved = str(Path("video.mkv").resolve())
+        assert cmd == ["ffprobe", "-v", "error", "-show_format", "-hide_banner", resolved]
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_custom_ffprobe_path(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "/usr/local/bin/ffprobe"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_with_pathlike(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate(Path("video.mkv"))
+        cmd = mock_run.call_args[0][0]
+        resolved = str(Path("video.mkv").resolve())
+        assert cmd[-1] == resolved
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_with_pipe_skips_resolve(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("pipe:")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-1] == "pipe:"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_with_url_skips_resolve(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("http://example.com/video.mp4")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-1] == "http://example.com/video.mp4"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_strips_whitespace_only_stderr(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"   \n")
+        ok, stderr = validate("video.mkv")
+        assert ok is True
+        assert stderr == "   \n"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_preserves_utf8_in_stderr(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"", stderr="ошибка кодека".encode()
+        )
+        ok, stderr = validate("video.mkv")
+        assert ok is False
+        assert stderr == "ошибка кодека"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_with_dash_skips_resolve(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("-")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[-1] == "-"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_replaces_invalid_utf8_in_stderr(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout=b"", stderr=b"bad codec \xff\xfe data"
+        )
+        ok, stderr = validate("video.mkv")
+        assert ok is False
+        assert "\ufffd" in stderr
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_subprocess_kwargs(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("video.mkv")
+        kwargs = mock_run.call_args[1]
+        assert kwargs["capture_output"] is True
+        assert kwargs["check"] is False
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_raises_on_permission_error(self, mock_run):
+        mock_run.side_effect = PermissionError("[Errno 13] Permission denied: '/usr/bin/ffprobe'")
+        with pytest.raises(FFmpegError, match="ffprobe could not be executed"):
+            validate("video.mkv")
+
+    def test_validate_raises_on_invalid_loglevel(self):
+        with pytest.raises(ValueError, match="invalid loglevel"):
+            validate("video.mkv", loglevel="warningg")
+
+    def test_validate_accepts_all_valid_loglevels(self):
+        valid = {"quiet", "panic", "fatal", "error", "warning", "info", "verbose", "debug", "trace"}
+        for level in valid:
+            with contextlib.suppress(FFmpegError, OSError):
+                validate("video.mkv", loglevel=level)
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_extra_args_coerced_to_str(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        validate("video.mkv", extra_args=(Path("-hide_banner"),))
+        cmd = mock_run.call_args[0][0]
+        assert "-hide_banner" in cmd
+        assert all(isinstance(a, str) for a in cmd)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -12,6 +12,7 @@ def test_all_names_accessible():
     assert hasattr(ffmpeg, "probe")
     assert hasattr(ffmpeg, "FFmpeg")
     assert hasattr(ffmpeg, "input")
+    assert hasattr(ffmpeg, "validate")
 
 
 def test_input_returns_ffmpeg_instance():
@@ -30,7 +31,12 @@ def test_ffmpeg_error_is_exception_subclass():
     assert issubclass(ffmpeg.FFmpegError, Exception)
 
 
+def test_validate_is_callable():
+    """ffmpeg.validate is callable."""
+    assert callable(ffmpeg.validate)
+
+
 def test_all_exports_match():
     """__all__ contains all expected public names."""
-    expected = {"FFmpegError", "Stream", "Format", "ProbeResult", "probe", "FFmpeg", "input"}
+    expected = {"FFmpegError", "Stream", "Format", "ProbeResult", "probe", "FFmpeg", "input", "validate"}
     assert set(ffmpeg.__all__) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ffmpeg-wrap"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgspec" },


### PR DESCRIPTION
## Summary
- New `validate()` function: runs ffprobe in validation mode, returns `(ok, stderr)` tuple
- Configurable `loglevel` (default `warning`) and `extra_args` for flexible validation
- Extracted `_resolve_input()` helper shared by `probe()` and `validate()`
- Broadened exception catch from `FileNotFoundError` to `OSError` in `probe()` and `FFmpeg.run()`
- Version bump 0.1.0 -> 0.2.0

## Test plan
- [x] 107 tests pass (33 new)
- [x] Verified with real MKV file (`Yomi_no_Tsugai_[02].mkv`) — warnings surface at `loglevel=warning`
- [x] loglevel validation rejects typos with `ValueError`
- [x] extra_args coerced to str, non-string elements handled
- [x] prek hooks pass