### PR TITLE
Ergonomics & introspection improvements (v0.3.0)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,6 +24,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Install ffmpeg (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y ffmpeg
+
+      - name: Install ffmpeg (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install --quiet ffmpeg
+
+      - name: Install ffmpeg (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install -y --no-progress ffmpeg
+
+      - name: Verify ffmpeg installation
+        run: ffmpeg -version
+        shell: bash
+
       - name: Install uv
         id: setup-uv
         uses: astral-sh/setup-uv@v8.0.0
@@ -35,5 +53,26 @@ jobs:
       - name: Install project
         run: uv sync --all-extras --dev
 
-      - name: Run tests
-        run: uv run --frozen pytest -q
+      - name: Download real media and run tests
+        run: uv run --frozen make
+        shell: bash
+
+  runtime-import:
+    name: Runtime-only import smoke test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          version: latest
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Import ffmpeg_wrap without dev dependencies
+        run: uv run --no-dev python -c "import ffmpeg_wrap; print(ffmpeg_wrap.__version__)"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ docs/
 .coverage
 .coverage.*
 htmlcov/
+
+# Downloaded real test media (fetched via `make download`)
+tests/file.mkv
+tests/file_2.mkv

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ wheels/
 !.github/
 
 docs/
+
+# Coverage artifacts
+.coverage
+.coverage.*
+htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+FILE_URL := https://github.com/GitBib/pymkv-files/raw/master/file.mkv
+FILE_TWO_URL := https://github.com/GitBib/pymkv-files/raw/master/file_2.mkv
+
+TEST_FILE := tests/file.mkv
+TEST_TWO_FILE := tests/file_2.mkv
+
+TEST_DIR := tests/
+
+.PHONY: test download clean
+
+# Download real media (if missing) then run the full suite, including the
+# integration tests that shell out to ffmpeg.
+test: download
+	@echo "ffmpeg version:"; ffmpeg -version | head -n1
+	uv run pytest $(TEST_DIR)
+
+download: $(TEST_FILE) $(TEST_TWO_FILE)
+
+$(TEST_FILE):
+	@if [ ! -f $(TEST_FILE) ]; then \
+		echo "Downloading $(TEST_FILE)..."; \
+		curl -fsSL $(FILE_URL) -o $(TEST_FILE); \
+		echo "Downloaded to $$(realpath $(TEST_FILE))"; \
+	else \
+		echo "$(TEST_FILE) already exists. Skipping download."; \
+	fi
+
+$(TEST_TWO_FILE):
+	@if [ ! -f $(TEST_TWO_FILE) ]; then \
+		echo "Downloading $(TEST_TWO_FILE)..."; \
+		curl -fsSL $(FILE_TWO_URL) -o $(TEST_TWO_FILE); \
+		echo "Downloaded to $$(realpath $(TEST_TWO_FILE))"; \
+	else \
+		echo "$(TEST_TWO_FILE) already exists. Skipping download."; \
+	fi
+
+clean:
+	rm -f $(TEST_FILE) $(TEST_TWO_FILE)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ except ffmpeg.FFmpegError as e:
     print(f"FFmpeg failed: {e}")
 ```
 
+`FFmpegError` carries structured introspection so you can classify a failure
+without re-parsing the message string. `str(e)` is still the human-readable
+message; the `returncode`, `stderr`, and `cmd` attributes describe the
+underlying process failure (each is `None` when not applicable):
+
+```python
+try:
+    ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().run()
+except ffmpeg.FFmpegError as e:
+    # Branch on the exit code / inspect stderr instead of scraping str(e).
+    if e.returncode == 1 and e.stderr and "No space left" in e.stderr:
+        raise
+    print(f"ffmpeg exited {e.returncode}: {e.stderr}")
+```
+
+This is the building block for consumer-side retry policies (e.g. retrying only
+on transient exit codes): the wrapper stays unopinionated about which failures
+are retryable and exposes the raw `returncode`/`stderr` for the caller to decide.
+
 ### Custom executable paths
 
 ```python
@@ -144,6 +163,123 @@ ok, stderr = ffmpeg.validate("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
 
 ffmpeg.input("input.mkv", ffmpeg_path="/usr/local/bin/ffmpeg").output("output.mp4").run()
 ```
+
+### Pipelines always start at `input()`
+
+Every chain begins with `ffmpeg.input(...)`, which returns the `FFmpeg` builder.
+There is no separate `output()`/`graph()` entry point: outputs, filters, and
+global flags are all methods on the chain rooted at an input.
+
+Synthetic sources (test patterns, silence, color) are inputs too — pass the
+`lavfi` virtual device as the input and the source description as its
+"filename":
+
+```python
+(
+    ffmpeg.input("anullsrc=channel_layout=stereo:sample_rate=48000", f="lavfi", t=5)
+    .output("silence.wav")
+    .overwrite_output()
+    .run()
+)
+# ffmpeg -f lavfi -t 5 -i anullsrc=channel_layout=stereo:sample_rate=48000 silence.wav
+```
+
+### Complex pipelines
+
+Use `filter_complex()` for a graph-level `-filter_complex` and `map()` to wire
+its labelled outputs to multiple output files. The filtergraph is emitted in a
+dedicated slot (after global args, before inputs), so its placement no longer
+depends on which output it is attached to:
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .filter_complex("[0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb]")
+    .output("full.mp4").map("[full]")
+    .output("thumb.mp4").map("[thumb]")
+    .overwrite_output()
+    .run()
+)
+# ffmpeg -filter_complex [0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb] \
+#   -i input.mkv -map [full] full.mp4 -map [thumb] thumb.mp4
+```
+
+For large graphs, read them from a file with `filter_complex_script()` (mutually
+exclusive with `filter_complex()` at runtime):
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .filter_complex_script("graph.txt")
+    .output("output.mp4")
+    .run()
+)
+# ffmpeg -filter_complex_script graph.txt -i input.mkv output.mp4
+```
+
+`map()` is repeatable and accepts raw specifiers, so a stream-preserving remux
+emits one `-map` per stream type:
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .output("output.mkv", c="copy")
+    .map("0:v").map("0:a").map("0:s")
+    .overwrite_output()
+    .run()
+)
+# ffmpeg -i input.mkv -c copy -map 0:v -map 0:a -map 0:s output.mkv
+```
+
+The same expansion works by passing a list directly: `output("out.mkv",
+map=["0:v", "0:a", "0:s"])`. `map(stream)` accepts a `Stream` from `probe()` and
+emits its per-type specifier (e.g. `0:s:0`); `map_stream("s", 0)` builds the
+specifier explicitly.
+
+When embedding a path in a filtergraph (e.g. `subtitles=`), escape it with
+`filter_arg_escape()` so colons and backslashes in the path do not break the
+graph:
+
+```python
+path = r"C:\videos\clip.srt"
+graph = f"subtitles={ffmpeg.filter_arg_escape(path)}"
+# subtitles='C\:\\videos\\clip.srt'
+```
+
+### Hardware acceleration
+
+Discover what the installed ffmpeg build actually supports at runtime instead of
+guessing. `encoders()` returns the full set of encoder names (cached per
+ffmpeg path); `has_encoder()` is a single-name membership check:
+
+```python
+if ffmpeg.has_encoder("h264_nvenc"):
+    video_codec = "h264_nvenc"
+else:
+    video_codec = "libx264"
+```
+
+Request a hardware decode/acceleration backend with the `hwaccel` input option,
+or the discoverable `hwaccel()` sugar — both emit `-hwaccel` before the input's
+`-i`:
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .hwaccel("cuda")
+    .output("output.mp4")
+    .codec("v", video_codec)
+    .overwrite_output()
+    .run()
+)
+# ffmpeg -hwaccel cuda -i input.mkv -c:v h264_nvenc output.mp4
+
+# Equivalent, set directly on the input:
+ffmpeg.input("input.mkv", hwaccel="cuda").output("output.mp4").codec("v", video_codec)
+```
+
+The wrapper stays unopinionated about encoder tuning: it reports what is
+available and lets you choose the codec and parameters.
 
 ## API Reference
 
@@ -181,11 +317,23 @@ Create a new `FFmpeg` builder chain starting with an input file.
 Fluent builder for FFmpeg commands.
 
 - `input(filename, **kwargs)` -- Add an input file with options.
-- `output(filename, **kwargs)` -- Add an output file with options.
+- `output(filename, **kwargs)` -- Add an output file with options. List/tuple values expand to a repeated flag (e.g. `map=["0:v", "0:a"]`).
 - `overwrite_output()` -- Add the `-y` flag to overwrite existing output files.
 - `global_args(*args)` -- Add global arguments before inputs.
+- `map(*specs)` -- Append one `-map` per spec on the current output. Accepts raw specifiers (`"0:v"`) or a `Stream` (emits its per-type specifier). Repeatable.
+- `map_stream(kind, ordinal, input=0)` -- Append `-map {input}:{kind}:{ordinal}` (e.g. `map_stream("s", 0)` -> `-map 0:s:0`).
+- `codec(kind, name)` -- `-c:{kind} {name}` on the current output (e.g. `codec("v", "libx264")`).
+- `bitrate(kind, value)` -- `-b:{kind} {value}`.
+- `quality(kind, value)` -- `-q:{kind} {value}`.
+- `audio_filter(chain)` / `video_filter(chain)` -- `-filter:a` / `-filter:v` on the current output.
+- `flag(*names)` -- Append bare `-{name}` switches (e.g. `flag("vn", "sn")`).
+- `filter_complex(graph_str)` -- Graph-level `-filter_complex`, emitted in a dedicated slot after global args and before inputs.
+- `filter_complex_script(path)` -- Graph-level `-filter_complex_script` (mutually exclusive with `filter_complex()` at runtime).
+- `hwaccel(name)` -- Input-side `-hwaccel {name}` sugar, emitted before `-i`.
+- `hide_banner()` -- `-hide_banner` global flag.
+- `loglevel(level)` -- `-loglevel {level}` global flag.
 - `compile()` -- Build the command as a list of strings without executing it.
-- `run(capture_stdout=False, capture_stderr=False)` -- Execute the command. Returns `(stdout, stderr)`. Values are `bytes` when the corresponding capture flag is `True`, or `None` otherwise. Raises `FFmpegError` on failure.
+- `run(capture_stdout=False, capture_stderr=False, text=False)` -- Execute the command. Returns `(stdout, stderr)`. With `text=True` the captured values are `str`; otherwise `bytes` (or `None` when the corresponding capture flag is `False`). Raises `FFmpegError` on failure.
 
 ### ProbeResult
 
@@ -193,15 +341,42 @@ Typed result from ffprobe.
 
 - `streams` -- List of `Stream` objects.
 - `format` -- Optional `Format` object.
+- `duration_seconds()` -- `float | None`. Delegates to `format.duration_seconds()`; `None` when there is no format.
 
 ### Stream
 
-A single stream from ffprobe output. Fields include `index`, `codec_name`, `codec_type`, `width`, `height`, `channels`, `sample_rate`, `duration`, `bit_rate`, `tags`, `disposition`.
+A single stream from ffprobe output. Fields include `index`, `codec_name`, `codec_type`, `type_index`, `width`, `height`, `channels`, `sample_rate`, `duration`, `bit_rate`, `tags`, `disposition`.
+
+- `map_specifier(input_index=0)` -- The per-type `-map` specifier for this stream (e.g. `0:s:0`), falling back to the absolute-index form for unknown `codec_type`.
+- `duration_seconds()` -- `float | None`. Parses `duration`, returning `None` for missing/`"N/A"`/non-numeric values.
+- `is_video` / `is_audio` / `is_subtitle` / `is_data` / `is_attachment` -- Properties comparing `codec_type` against `CodecType`. All `False` for unknown/`None`.
+- `is_text_subtitle` / `is_image_subtitle` -- Best-effort properties classifying a subtitle stream by `codec_name`.
 
 ### Format
 
 The format section from ffprobe output. Fields include `filename`, `nb_streams`, `nb_programs`, `format_name`, `format_long_name`, `start_time`, `duration`, `size`, `bit_rate`, `probe_score`, `tags`.
 
+- `duration_seconds()` -- `float | None`. Parses `duration`, returning `None` for missing/`"N/A"`/non-numeric values (the raw `duration: str` is preserved).
+
+### CodecType
+
+`StrEnum` of the known ffprobe `codec_type` values (`VIDEO`, `AUDIO`, `SUBTITLE`, `DATA`, `ATTACHMENT`). Used by the `Stream` predicates. `Stream.codec_type` stays typed `str | None` so exotic values still decode without `ValidationError` — compare against these members rather than retyping the field.
+
+### encoders(ffmpeg_path="ffmpeg")
+
+Return the set of encoder names supported by the installed ffmpeg build.
+
+- Parses `ffmpeg -hide_banner -encoders`; the result is cached per `ffmpeg_path`.
+- Returns: `frozenset[str]`.
+
+### has_encoder(name, ffmpeg_path="ffmpeg")
+
+`bool`. Whether `name` is in `encoders(ffmpeg_path)`. Use this instead of hard-coding encoder availability.
+
+### filter_arg_escape(value)
+
+`str`. Escape a value for use inside a filtergraph argument (e.g. a `subtitles=` path), handling `\`, `:`, and `'`, and wrapping the result in single quotes.
+
 ### FFmpegError
 
-Exception raised when FFmpeg or ffprobe operations fail.
+Exception raised when FFmpeg or ffprobe operations fail. `str(e)` is the human-readable message; the keyword-only attributes `stderr` (`str | None`), `returncode` (`int | None`), and `cmd` (`list[str] | None`) describe the underlying process failure and are `None` when not applicable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,4 @@ ignore = [
 "__init__.py" = ["TID252", "F401", "A004"]
 "_builder.py" = ["A001", "A002", "A004"]
 "test_*.py" = ["T20", "ANN", "S", "ERA", "PLR", "ARG", "FBT", "SLF", "E402", "E501", "B007", "G"]
+"conftest.py" = ["ARG"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-wrap"
-version = "0.2.0"
+version = "0.3.0"
 description = "Typed fluent FFmpeg/ffprobe wrapper with msgspec models"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -71,5 +71,5 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["TID252", "F401", "A004"]
-"_builder.py" = ["A001", "A004"]
+"_builder.py" = ["A001", "A002", "A004"]
 "test_*.py" = ["T20", "ANN", "S", "ERA", "PLR", "ARG", "FBT", "SLF", "E402", "E501", "B007", "G"]

--- a/src/ffmpeg_wrap/__init__.py
+++ b/src/ffmpeg_wrap/__init__.py
@@ -1,17 +1,23 @@
 from importlib.metadata import version
 
 from ._builder import FFmpeg, input
+from ._encoders import encoders, has_encoder
 from ._errors import FFmpegError
-from ._probe import Format, ProbeResult, Stream, probe, validate
+from ._filters import filter_arg_escape
+from ._probe import CodecType, Format, ProbeResult, Stream, probe, validate
 
 __version__ = version("ffmpeg-wrap")
 
 __all__ = [
+    "CodecType",
     "FFmpeg",
     "FFmpegError",
     "Format",
     "ProbeResult",
     "Stream",
+    "encoders",
+    "filter_arg_escape",
+    "has_encoder",
     "input",
     "probe",
     "validate",

--- a/src/ffmpeg_wrap/_builder.py
+++ b/src/ffmpeg_wrap/_builder.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import collections
+import locale
 import logging
 import os
 import subprocess
-from typing import Any
+import sys
+import threading
+from typing import Any, Literal, overload
 
 from ._errors import FFmpegError
+from ._probe import Stream
 
 logger = logging.getLogger("ffmpeg_wrap")
 
@@ -17,6 +22,7 @@ class FFmpeg:
         self._inputs: list[dict[str, Any]] = []
         self._outputs: list[dict[str, Any]] = []
         self._global_args: list[str] = []
+        self._filter_graph_args: list[str] = []
         self._overwrite: bool = False
         self._ffmpeg_path: str = ffmpeg_path
 
@@ -32,6 +38,8 @@ class FFmpeg:
             cmd.append("-y")
 
         cmd.extend(self._global_args)
+
+        cmd.extend(self._filter_graph_args)
 
         for inp in self._inputs:
             for k, v in inp["kwargs"].items():
@@ -71,6 +79,185 @@ class FFmpeg:
         self._outputs.append({"filename": os.fsdecode(filename), "kwargs": kwargs})
         return self
 
+    def _append_output_list(self, key: str, values: list[str]) -> None:
+        """Append ``values`` to a repeatable option list on the current output.
+
+        Normalizes any existing scalar value (e.g. from ``output(map="0:v")``)
+        into a list so that mixing the kwarg and method forms is consistent.
+        """
+        if not self._outputs:
+            msg = f"call .output(...) before .{key}(...)"
+            raise FFmpegError(msg)
+        kwargs = self._outputs[-1]["kwargs"]
+        existing = kwargs.get(key)
+        if existing is None:
+            items: list[str] = []
+        elif isinstance(existing, (list, tuple)):
+            items = list(existing)
+        else:
+            items = [existing]
+        items.extend(values)
+        kwargs[key] = items
+
+    def map(self, *specs: str | Stream) -> FFmpeg:
+        """Add one or more ``-map`` specifiers to the current output.
+
+        Accepts raw specifier strings (``"0:v"``) and ``Stream`` objects. For a
+        ``Stream``, the per-type specifier (e.g. ``0:s:0``) is used, computed
+        from probe data rather than the raw absolute index.
+
+        Args:
+            *specs: Map specifiers as strings or ``Stream`` objects.
+
+        Returns:
+            Self for chaining.
+        """
+        tokens = [spec.map_specifier() if isinstance(spec, Stream) else str(spec) for spec in specs]
+        self._append_output_list("map", tokens)
+        return self
+
+    def map_stream(self, kind: str, ordinal: int, input: int = 0) -> FFmpeg:
+        """Add a per-type ``-map`` specifier to the current output.
+
+        Args:
+            kind: Stream-type letter (e.g. ``"v"``, ``"a"``, ``"s"``).
+            ordinal: Zero-based index within that stream type.
+            input: Index of the ffmpeg input to map from.
+
+        Returns:
+            Self for chaining.
+        """
+        self._append_output_list("map", [f"{input}:{kind}:{ordinal}"])
+        return self
+
+    def _set_input_option(self, key: str, value: Any) -> None:
+        """Set a single option on the current input's kwargs.
+
+        Raises ``FFmpegError`` if no input has been added yet.
+        """
+        if not self._inputs:
+            msg = f"call .input(...) before setting option {key!r}"
+            raise FFmpegError(msg)
+        self._inputs[-1]["kwargs"][key] = value
+
+    def hwaccel(self, name: str) -> FFmpeg:
+        """Request a hardware-acceleration backend on the current input.
+
+        Discoverable sugar for ``input(..., hwaccel=name)``: emits
+        ``-hwaccel {name}`` before the current input's ``-i`` (e.g.
+        ``hwaccel("cuda")`` -> ``-hwaccel cuda -i in.mkv``).
+
+        Args:
+            name: Hardware-acceleration backend (e.g. ``"cuda"``, ``"vaapi"``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._set_input_option("hwaccel", name)
+        return self
+
+    def _set_output_option(self, key: str, value: Any) -> None:
+        """Set a single option on the current output's kwargs.
+
+        Raises ``FFmpegError`` if no output has been added yet.
+        """
+        if not self._outputs:
+            msg = f"call .output(...) before setting option {key!r}"
+            raise FFmpegError(msg)
+        self._outputs[-1]["kwargs"][key] = value
+
+    def codec(self, kind: str, name: str) -> FFmpeg:
+        """Set the codec for a stream type on the current output.
+
+        Emits ``-c:{kind} {name}`` (e.g. ``codec("v", "libx265")`` ->
+        ``-c:v libx265``).
+
+        Args:
+            kind: Stream-type letter (e.g. ``"v"``, ``"a"``, ``"s"``).
+            name: Codec name (e.g. ``"libx265"``, ``"copy"``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._set_output_option(f"c:{kind}", name)
+        return self
+
+    def bitrate(self, kind: str, value: str | int) -> FFmpeg:
+        """Set the bitrate for a stream type on the current output.
+
+        Emits ``-b:{kind} {value}`` (e.g. ``bitrate("v", "2M")`` ->
+        ``-b:v 2M``).
+
+        Args:
+            kind: Stream-type letter (e.g. ``"v"``, ``"a"``).
+            value: Bitrate value (e.g. ``"2M"``, ``128000``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._set_output_option(f"b:{kind}", value)
+        return self
+
+    def quality(self, kind: str, value: str | int) -> FFmpeg:
+        """Set the quality scale for a stream type on the current output.
+
+        Emits ``-q:{kind} {value}`` (e.g. ``quality("a", 2)`` -> ``-q:a 2``).
+
+        Args:
+            kind: Stream-type letter (e.g. ``"v"``, ``"a"``).
+            value: Quality value.
+
+        Returns:
+            Self for chaining.
+        """
+        self._set_output_option(f"q:{kind}", value)
+        return self
+
+    def audio_filter(self, chain: str) -> FFmpeg:
+        """Set the audio filter chain on the current output.
+
+        Emits ``-filter:a {chain}``.
+
+        Args:
+            chain: Filter chain string (e.g. ``"loudnorm"``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._set_output_option("filter:a", chain)
+        return self
+
+    def video_filter(self, chain: str) -> FFmpeg:
+        """Set the video filter chain on the current output.
+
+        Emits ``-filter:v {chain}``.
+
+        Args:
+            chain: Filter chain string (e.g. ``"scale=1280:-2"``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._set_output_option("filter:v", chain)
+        return self
+
+    def flag(self, *names: str) -> FFmpeg:
+        """Add one or more valueless switches to the current output.
+
+        Emits a bare ``-{name}`` token per name (e.g. ``flag("vn", "sn")`` ->
+        ``-vn -sn``). This is the intentional way to request a switch; note the
+        contrast with ``output(..., vn=None)``, which *omits* the flag entirely.
+
+        Args:
+            *names: Switch names without the leading dash (e.g. ``"vn"``).
+
+        Returns:
+            Self for chaining.
+        """
+        for name in names:
+            self._set_output_option(name, True)
+        return self
+
     def overwrite_output(self) -> FFmpeg:
         """Add the -y flag to overwrite output files.
 
@@ -92,20 +279,103 @@ class FFmpeg:
         self._global_args.extend(args)
         return self
 
+    def hide_banner(self) -> FFmpeg:
+        """Add the ``-hide_banner`` global flag.
+
+        Thin sugar over :meth:`global_args`; emitted in the global slot.
+
+        Returns:
+            Self for chaining.
+        """
+        self._global_args.append("-hide_banner")
+        return self
+
+    def loglevel(self, level: str) -> FFmpeg:
+        """Set the ffmpeg log level via ``-loglevel {level}``.
+
+        Thin sugar over :meth:`global_args`; emitted in the global slot.
+
+        Args:
+            level: Log level (e.g. ``"error"``, ``"warning"``, ``"verbose"``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._global_args.extend(["-loglevel", level])
+        return self
+
+    def filter_complex(self, graph_str: str) -> FFmpeg:
+        """Set a graph-level ``-filter_complex`` filtergraph.
+
+        Emits ``-filter_complex <graph_str>`` in a dedicated slot after global
+        args and before inputs, so placement no longer depends on parking the
+        option on an output. Mutually exclusive with
+        :meth:`filter_complex_script` at runtime (not enforced here).
+
+        Args:
+            graph_str: The filtergraph string (e.g.
+                ``"[0:v]split=2[a][b]"``).
+
+        Returns:
+            Self for chaining.
+        """
+        self._filter_graph_args = ["-filter_complex", graph_str]
+        return self
+
+    def filter_complex_script(self, path: str | os.PathLike[str]) -> FFmpeg:
+        """Read a graph-level filtergraph from a file via ``-filter_complex_script``.
+
+        Emits ``-filter_complex_script <path>`` in the same dedicated slot as
+        :meth:`filter_complex` (after global args, before inputs). Mutually
+        exclusive with :meth:`filter_complex` at runtime (not enforced here).
+
+        Args:
+            path: Path to a file containing the filtergraph.
+
+        Returns:
+            Self for chaining.
+        """
+        self._filter_graph_args = ["-filter_complex_script", os.fsdecode(path)]
+        return self
+
+    @overload
+    def run(
+        self,
+        capture_stdout: bool = ...,
+        capture_stderr: bool = ...,
+        *,
+        text: Literal[False] = ...,
+    ) -> tuple[bytes | None, bytes | None]: ...
+
+    @overload
+    def run(
+        self,
+        capture_stdout: bool = ...,
+        capture_stderr: bool = ...,
+        *,
+        text: Literal[True],
+    ) -> tuple[str | None, str | None]: ...
+
     def run(
         self,
         capture_stdout: bool = False,
         capture_stderr: bool = False,
-    ) -> tuple[bytes | None, bytes | None]:
+        *,
+        text: bool = False,
+    ) -> tuple[bytes | None, bytes | None] | tuple[str | None, str | None]:
         """Build and execute the FFmpeg command.
 
         Args:
             capture_stdout: Whether to capture stdout.
             capture_stderr: Whether to capture stderr.
+            text: When True, decode stdout/stderr (and ``FFmpegError.stderr``)
+                as text using the platform default encoding; otherwise return
+                raw bytes.
 
         Returns:
-            Tuple of (stdout, stderr). Values are bytes when the
-            corresponding capture flag is True, or None otherwise.
+            Tuple of (stdout, stderr). Values are ``str`` when ``text=True``
+            else ``bytes`` when the corresponding capture flag is True, or
+            None otherwise.
 
         Raises:
             FFmpegError: If ffmpeg fails.
@@ -113,32 +383,145 @@ class FFmpeg:
         cmd = self.compile()
 
         stdout_dest = subprocess.PIPE if capture_stdout else None
-        stderr_dest = subprocess.PIPE if capture_stderr else None
 
         logger.debug(f"Running ffmpeg command: {' '.join(cmd)}")
 
         try:
-            process = subprocess.run(
-                cmd,
-                stdout=stdout_dest,
-                stderr=stderr_dest,
-                check=True,
-                text=False,
-            )
-            return process.stdout, process.stderr
+            if capture_stderr:
+                # Caller wants stderr returned: capture it directly.
+                process = subprocess.run(
+                    cmd,
+                    stdout=stdout_dest,
+                    stderr=subprocess.PIPE,
+                    check=True,
+                    text=text,
+                )
+                return process.stdout, process.stderr
+            # Caller does not capture stderr: tee ffmpeg's stderr to the
+            # inherited stderr stream in real time (preserving the live
+            # progress output of a bare ``run()``) while collecting it, so the
+            # failure path can still populate ``FFmpegError.stderr`` without
+            # silently buffering an entire successful run in memory.
+            stdout_data = self._run_tee(cmd, stdout_dest, text)
+            return stdout_data, None
         except subprocess.CalledProcessError as e:
-            err_msg = e.stderr.decode("utf-8", errors="replace") if e.stderr else str(e)
+            if e.stderr is None:
+                stderr_text: str | None = None
+            elif isinstance(e.stderr, str):
+                stderr_text = e.stderr
+            else:
+                stderr_text = e.stderr.decode("utf-8", errors="replace")
+            err_msg = stderr_text or str(e)
             logger.error(f"FFmpeg command failed: {err_msg}")
-            raise FFmpegError(f"ffmpeg error: {err_msg}") from e
+            raise FFmpegError(
+                f"ffmpeg error: {err_msg}",
+                stderr=stderr_text,
+                returncode=e.returncode,
+                cmd=cmd,
+            ) from e
         except OSError as e:
             logger.error(f"ffmpeg could not be executed: {e}")
-            raise FFmpegError(f"ffmpeg could not be executed: {e}") from e
+            raise FFmpegError(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+
+    # Maximum stderr tail retained for ``FFmpegError`` (ffmpeg's diagnostics
+    # land at the end of the stream, so a bounded tail keeps memory flat on
+    # long jobs while still capturing the actionable error text).
+    _STDERR_TAIL_BYTES = 256 * 1024
+
+    @staticmethod
+    def _decode_text(data: bytes, encoding: str) -> str:
+        """Decode tee-path bytes the way ``subprocess.run(text=True)`` returns text.
+
+        Mirrors subprocess's universal-newline translation (``\\r\\n`` and
+        ``\\r`` collapse to ``\\n``) so the returned stdout and
+        ``FFmpegError.stderr`` have the same shape regardless of which ``run()``
+        path produced them. Decoding stays lenient (``errors="replace"``)
+        rather than subprocess's strict default: a stray byte must never turn a
+        finished run — or the error report for a failed one — into a
+        ``UnicodeDecodeError``.
+        """
+        return data.decode(encoding, errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+
+    @staticmethod
+    def _run_tee(cmd: list[str], stdout_dest: int | None, text: bool) -> bytes | str | None:
+        """Run ``cmd`` forwarding stderr to the terminal while collecting it.
+
+        The child runs in binary mode so the pump can forward stderr in fixed
+        chunks (``read1``) as bytes arrive. ffmpeg writes its progress as
+        carriage-return-terminated updates (``frame=...\\r``) rather than
+        newline-terminated lines, so a line-oriented read would withhold all of
+        it until EOF; chunked reads preserve the live progress of a bare
+        ``run()``. Only a bounded tail of stderr is retained, and it is decoded
+        and joined solely on the failure path — successful runs keep memory
+        flat. On a non-zero exit raises ``CalledProcessError`` carrying the
+        collected stderr (and stdout) so the caller can build ``FFmpegError``.
+        """
+        encoding = locale.getpreferredencoding(False)
+        # ``sys.stderr`` is normally a text wrapper over a binary ``.buffer``,
+        # which takes the raw byte chunks directly. When the active
+        # ``sys.stderr`` is text-only (no ``.buffer`` — e.g. a capturing
+        # wrapper) or ``None``, fall back and decode per chunk so the live tee
+        # is preserved instead of silently dropped on a bytes-to-text write.
+        buffer = getattr(sys.stderr, "buffer", None)
+        if buffer is not None:
+            sink, sink_is_text = buffer, False
+        else:
+            sink, sink_is_text = sys.stderr, True
+        tail: collections.deque[bytes] = collections.deque()
+        tail_len = 0
+
+        def _pump(stream: Any) -> None:
+            nonlocal tail_len
+            reader = stream.read1 if hasattr(stream, "read1") else stream.read
+            while True:
+                chunk = reader(65536)
+                if not chunk:
+                    break
+                try:
+                    # Forward raw bytes (or a lenient per-chunk decode for a
+                    # text-only sink) WITHOUT newline translation, so ffmpeg's
+                    # ``\r`` progress updates still overwrite in place on the
+                    # terminal rather than scrolling.
+                    sink.write(chunk.decode(encoding, errors="replace") if sink_is_text else chunk)
+                    sink.flush()
+                except (OSError, ValueError, TypeError, AttributeError):
+                    pass
+                tail.append(chunk)
+                tail_len += len(chunk)
+                while tail_len > FFmpeg._STDERR_TAIL_BYTES and len(tail) > 1:
+                    tail_len -= len(tail.popleft())
+            stream.close()
+
+        with subprocess.Popen(cmd, stdout=stdout_dest, stderr=subprocess.PIPE) as process:
+            pump = threading.Thread(target=_pump, args=(process.stderr,), daemon=True)
+            pump.start()
+            stdout_data = process.stdout.read() if process.stdout is not None else None
+            process.wait()
+            pump.join()
+
+        # The returned stdout and ``FFmpegError.stderr`` mirror
+        # ``subprocess.run(text=True)`` (see ``_decode_text``): platform-default
+        # encoding with universal-newline translation, leniently decoded.
+        if text and isinstance(stdout_data, bytes):
+            stdout_data = FFmpeg._decode_text(stdout_data, encoding)
+        if process.returncode:
+            stderr_bytes = b"".join(tail)
+            stderr_data: bytes | str = FFmpeg._decode_text(stderr_bytes, encoding) if text else stderr_bytes
+            raise subprocess.CalledProcessError(process.returncode, cmd, output=stdout_data, stderr=stderr_data)
+        return stdout_data
 
 
 def _convert_arg(key: str, value: Any) -> list[str]:
     """Convert a kwarg pair to command-line arguments."""
     if value is None or value is False:
         return []
+    if isinstance(value, (list, tuple)):
+        # Repeatable flag: emit it once per element (``map=["0:v", "1:a"]`` ->
+        # ``-map 0:v -map 1:a``). Each element reuses the scalar rules above.
+        args: list[str] = []
+        for item in value:
+            args.extend(_convert_arg(key, item))
+        return args
     flag = f"-{key}"
     if value is True:
         return [flag]

--- a/src/ffmpeg_wrap/_encoders.py
+++ b/src/ffmpeg_wrap/_encoders.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+
+from ._errors import FFmpegError
+
+logger = logging.getLogger("ffmpeg_wrap")
+
+# Cache of parsed encoder sets, keyed on the ffmpeg binary path so a process
+# can introspect more than one build. Cleared in tests via
+# ``_clear_encoders_cache``.
+_ENCODERS_CACHE: dict[str, frozenset[str]] = {}
+
+
+def _parse_encoders(output: str) -> frozenset[str]:
+    """Extract encoder names from ``ffmpeg -encoders`` output.
+
+    The listing has a flags legend, a ``------`` separator, then one encoder
+    per line as ``<flags> <name> <description>``. Only lines after the
+    separator are parsed, taking the second whitespace-delimited token as the
+    encoder name.
+    """
+    names: set[str] = set()
+    seen_separator = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not seen_separator:
+            if stripped and set(stripped) == {"-"}:
+                seen_separator = True
+            continue
+        parts = stripped.split()
+        if len(parts) >= 2:
+            names.add(parts[1])
+    return frozenset(names)
+
+
+def encoders(ffmpeg_path: str = "ffmpeg") -> frozenset[str]:
+    """Return the set of encoder names reported by ``ffmpeg -encoders``.
+
+    The result is cached per ``ffmpeg_path`` for the lifetime of the process.
+    Use :func:`has_encoder` for a single-name membership check.
+
+    Args:
+        ffmpeg_path: Path to the ffmpeg executable.
+
+    Returns:
+        A frozenset of encoder names (e.g. ``"libx264"``, ``"h264_nvenc"``).
+
+    Raises:
+        FFmpegError: If ffmpeg cannot be run or exits non-zero.
+    """
+    cached = _ENCODERS_CACHE.get(ffmpeg_path)
+    if cached is not None:
+        return cached
+
+    cmd = [ffmpeg_path, "-hide_banner", "-encoders"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, check=True, text=True)
+    except subprocess.CalledProcessError as e:
+        stderr_text = e.stderr if isinstance(e.stderr, str) else None
+        err_msg = stderr_text or str(e)
+        logger.error(f"ffmpeg -encoders failed: {err_msg}")
+        raise FFmpegError(
+            f"ffmpeg -encoders error: {err_msg}",
+            stderr=stderr_text,
+            returncode=e.returncode,
+            cmd=cmd,
+        ) from e
+    except OSError as e:
+        logger.error(f"ffmpeg could not be executed: {e}")
+        raise FFmpegError(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+
+    parsed = _parse_encoders(result.stdout)
+    _ENCODERS_CACHE[ffmpeg_path] = parsed
+    return parsed
+
+
+def has_encoder(name: str, ffmpeg_path: str = "ffmpeg") -> bool:
+    """Return whether ``name`` is an available ffmpeg encoder.
+
+    Args:
+        name: Encoder name to check (e.g. ``"h264_nvenc"``).
+        ffmpeg_path: Path to the ffmpeg executable.
+
+    Returns:
+        True iff ``name`` appears in :func:`encoders`.
+
+    Raises:
+        FFmpegError: If ffmpeg cannot be run or exits non-zero.
+    """
+    return name in encoders(ffmpeg_path)
+
+
+def _clear_encoders_cache() -> None:
+    """Clear the per-path encoder cache (test-only hook)."""
+    _ENCODERS_CACHE.clear()

--- a/src/ffmpeg_wrap/_errors.py
+++ b/src/ffmpeg_wrap/_errors.py
@@ -1,2 +1,28 @@
+from __future__ import annotations
+
+
 class FFmpegError(Exception):
-    """Custom exception for FFmpeg errors."""
+    """Custom exception for FFmpeg errors.
+
+    Carries structured introspection from the underlying process failure so
+    callers can branch on the exit code or inspect stderr without re-parsing
+    ``str(e)``. The message remains ``args[0]`` so ``str(e)`` is unchanged.
+
+    Attributes:
+        stderr: Decoded stderr from the failed process, if captured.
+        returncode: Process exit code, if available.
+        cmd: The command that was executed, if available.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stderr: str | None = None,
+        returncode: int | None = None,
+        cmd: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.stderr = stderr
+        self.returncode = returncode
+        self.cmd = cmd

--- a/src/ffmpeg_wrap/_filters.py
+++ b/src/ffmpeg_wrap/_filters.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+
+def filter_arg_escape(value: str) -> str:
+    r"""Escape a value for safe embedding in a filtergraph option.
+
+    ffmpeg parses a filtergraph at two levels, and a value pasted into a filter
+    option (such as a ``subtitles=`` path) must survive both:
+
+    * The *filter-option* parser, where ``:`` separates options and ``\``/``'``
+      are escaping/quoting characters. A raw colon (every Windows drive path,
+      and POSIX paths containing one) is otherwise read as an option separator,
+      so ffmpeg mis-parses the tail (e.g. ``original_size``). This level is
+      handled by backslash-escaping ``\``, ``'`` and ``:``.
+    * The *filtergraph* parser, where ``'`` quotes and ``[],;`` are special.
+      This level is handled by wrapping the whole value in single quotes; a
+      literal ``'`` is emitted via the close/escape/reopen idiom (``'\''``).
+
+    Single-quote wrapping alone is **not** sufficient: the colon still reaches
+    the filter-option parser and splits the value, so the backslash escaping is
+    required as well. The result parses back to the original ``value``.
+
+    Typical use is building a ``subtitles=`` (or any path-bearing) filter::
+
+        graph = f"subtitles={filter_arg_escape(path)}"
+
+    Args:
+        value: The raw string to escape (e.g. a filesystem path).
+
+    Returns:
+        The escaped, single-quote-wrapped token.
+    """
+    # Filter-option level: escape backslash first, then quote and colon.
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'").replace(":", "\\:")
+    # Filtergraph level: single-quote wrap, emitting any embedded ' literally.
+    return "'" + escaped.replace("'", "'\\''") + "'"

--- a/src/ffmpeg_wrap/_probe.py
+++ b/src/ffmpeg_wrap/_probe.py
@@ -1,7 +1,19 @@
 import logging
 import os
 import subprocess
+import sys
 from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:  # Python 3.10: StrEnum was added in 3.11
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Minimal ``enum.StrEnum`` backport for Python 3.10."""
+
+        __str__ = str.__str__
+
 
 import msgspec
 
@@ -9,7 +21,62 @@ from ._errors import FFmpegError
 
 logger = logging.getLogger("ffmpeg_wrap")
 
+
+class CodecType(StrEnum):
+    """The known ffprobe ``codec_type`` values.
+
+    Used for the typed predicates on :class:`Stream` (``is_video`` etc.).
+    Note that :attr:`Stream.codec_type` stays typed ``str | None`` rather than
+    this enum: ffmpeg can report ``codec_type`` values outside this set, and
+    decoding into a strict enum would raise ``msgspec.ValidationError`` on such
+    files. Compare against these members instead of retyping the field.
+    """
+
+    VIDEO = "video"
+    AUDIO = "audio"
+    SUBTITLE = "subtitle"
+    DATA = "data"
+    ATTACHMENT = "attachment"
+
+
+# Best-effort classification of subtitle ``codec_name`` values into text-based
+# vs image-based (bitmap) subtitles. Not exhaustive: ffmpeg ships many subtitle
+# codecs, and an unrecognised name yields ``False`` from both predicates.
+_TEXT_SUBTITLE_CODECS = frozenset(
+    {
+        "subrip",
+        "srt",
+        "ass",
+        "ssa",
+        "webvtt",
+        "mov_text",
+        "text",
+        "eia_608",
+        "subviewer",
+        "microdvd",
+    }
+)
+_IMAGE_SUBTITLE_CODECS = frozenset(
+    {
+        "hdmv_pgs_subtitle",
+        "dvd_subtitle",
+        "dvb_subtitle",
+        "xsub",
+        "dvb_teletext",
+    }
+)
+
 _FFPROBE_LOGLEVELS = frozenset({"quiet", "panic", "fatal", "error", "warning", "info", "verbose", "debug", "trace"})
+
+# Maps an ffprobe ``codec_type`` to its ffmpeg stream-specifier letter
+# (e.g. ``"subtitle"`` -> ``"s"`` so the 1st subtitle stream is ``0:s:0``).
+_STREAM_TYPE_LETTERS = {
+    "video": "v",
+    "audio": "a",
+    "subtitle": "s",
+    "data": "d",
+    "attachment": "t",
+}
 
 # Known ffmpeg protocols that use "name:" or "name:arg" syntax (no "://").
 # Kept as a whitelist to avoid matching POSIX filenames containing colons.
@@ -31,6 +98,19 @@ _FFMPEG_SIMPLE_PROTOCOLS = frozenset(
         "subfile",
     }
 )
+
+
+def _parse_duration(value: str | None) -> float | None:
+    """Parse an ffprobe duration string to seconds.
+
+    Returns ``None`` for ``None`` or non-numeric values (e.g. ``"N/A"``).
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
 
 
 def _is_special_input(filename: str) -> bool:
@@ -87,6 +167,81 @@ class Stream(msgspec.Struct):
     bit_rate: str | None = None
     tags: dict[str, str] | None = None
     disposition: dict[str, int] | None = None
+    # Per-type ordinal within this stream's ``codec_type`` (the ``N`` in the
+    # ffmpeg specifier ``0:s:N``). Populated by ``probe()``; defaults to 0 when
+    # a ``Stream`` is constructed or decoded outside of ``probe()``.
+    type_index: int = 0
+
+    def map_specifier(self, input_index: int = 0) -> str:
+        """Return the ffmpeg ``-map`` specifier for this stream.
+
+        Emits the per-type form ``{input}:{letter}:{ordinal}`` (e.g. ``0:s:0``)
+        derived from ``codec_type`` and ``type_index``. When ``codec_type`` is
+        unknown or ``None``, falls back to the unambiguous absolute-index form
+        ``{input}:{index}``.
+
+        Args:
+            input_index: Index of the ffmpeg input the stream belongs to.
+
+        Returns:
+            The map specifier string.
+        """
+        letter = _STREAM_TYPE_LETTERS.get(self.codec_type or "")
+        if letter is None:
+            return f"{input_index}:{self.index}"
+        return f"{input_index}:{letter}:{self.type_index}"
+
+    def duration_seconds(self) -> float | None:
+        """Return this stream's ``duration`` as ``float`` seconds.
+
+        Returns ``None`` when ``duration`` is missing or non-numeric
+        (e.g. ``"N/A"``); the raw ``duration`` string is preserved.
+        """
+        return _parse_duration(self.duration)
+
+    @property
+    def is_video(self) -> bool:
+        """True iff ``codec_type`` is ``"video"``."""
+        return self.codec_type == CodecType.VIDEO
+
+    @property
+    def is_audio(self) -> bool:
+        """True iff ``codec_type`` is ``"audio"``."""
+        return self.codec_type == CodecType.AUDIO
+
+    @property
+    def is_subtitle(self) -> bool:
+        """True iff ``codec_type`` is ``"subtitle"``."""
+        return self.codec_type == CodecType.SUBTITLE
+
+    @property
+    def is_data(self) -> bool:
+        """True iff ``codec_type`` is ``"data"``."""
+        return self.codec_type == CodecType.DATA
+
+    @property
+    def is_attachment(self) -> bool:
+        """True iff ``codec_type`` is ``"attachment"``."""
+        return self.codec_type == CodecType.ATTACHMENT
+
+    @property
+    def is_text_subtitle(self) -> bool:
+        """True iff this is a subtitle stream with a known text-based codec.
+
+        Best-effort: driven by a documented codec-name set (``subrip``,
+        ``ass``, ``ssa``, ...). Unknown subtitle codecs return ``False``.
+        """
+        return self.is_subtitle and self.codec_name in _TEXT_SUBTITLE_CODECS
+
+    @property
+    def is_image_subtitle(self) -> bool:
+        """True iff this is a subtitle stream with a known image-based codec.
+
+        Best-effort: driven by a documented codec-name set
+        (``hdmv_pgs_subtitle``, ``dvd_subtitle``, ``dvb_subtitle``, ...).
+        Unknown subtitle codecs return ``False``.
+        """
+        return self.is_subtitle and self.codec_name in _IMAGE_SUBTITLE_CODECS
 
 
 class Format(msgspec.Struct):
@@ -104,12 +259,39 @@ class Format(msgspec.Struct):
     probe_score: int | None = None
     tags: dict[str, str] | None = None
 
+    def duration_seconds(self) -> float | None:
+        """Return the container ``duration`` as ``float`` seconds.
+
+        Returns ``None`` when ``duration`` is missing or non-numeric
+        (e.g. ``"N/A"``); the raw ``duration`` string is preserved.
+        """
+        return _parse_duration(self.duration)
+
 
 class ProbeResult(msgspec.Struct):
     """Typed result of running ffprobe on a file."""
 
     streams: list[Stream]
     format: Format | None = None
+
+    def duration_seconds(self) -> float | None:
+        """Return the container ``duration`` as ``float`` seconds.
+
+        Delegates to ``self.format``; returns ``None`` when ``format`` is
+        absent or its ``duration`` is missing/non-numeric.
+        """
+        if self.format is None:
+            return None
+        return self.format.duration_seconds()
+
+
+def _assign_type_indices(streams: list[Stream]) -> None:
+    """Set each stream's per-type ordinal (the ``N`` in ``0:<type>:N``)."""
+    counters: dict[str | None, int] = {}
+    for stream in streams:
+        ordinal = counters.get(stream.codec_type, 0)
+        stream.type_index = ordinal
+        counters[stream.codec_type] = ordinal + 1
 
 
 def validate(
@@ -150,7 +332,7 @@ def validate(
         result = subprocess.run(cmd, capture_output=True, check=False, text=False)
     except OSError as e:
         logger.error(f"ffprobe could not be executed: {e}")
-        raise FFmpegError(f"ffprobe could not be executed: {e}") from e
+        raise FFmpegError(f"ffprobe could not be executed: {e}", cmd=cmd) from e
     stderr_text = result.stderr.decode("utf-8", errors="replace")
     ok = result.returncode == 0 and not stderr_text.strip()
     return (ok, stderr_text)
@@ -188,14 +370,22 @@ def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> Pr
             check=True,
             text=False,
         )
-        return msgspec.json.decode(result.stdout, type=ProbeResult)
+        parsed = msgspec.json.decode(result.stdout, type=ProbeResult)
+        _assign_type_indices(parsed.streams)
+        return parsed
     except subprocess.CalledProcessError as e:
-        err_msg = e.stderr.decode("utf-8", errors="replace") if e.stderr else str(e)
+        stderr_text = e.stderr.decode("utf-8", errors="replace") if e.stderr else None
+        err_msg = stderr_text or str(e)
         logger.error(f"ffprobe failed: {err_msg}")
-        raise FFmpegError(f"ffprobe error: {err_msg}") from e
+        raise FFmpegError(
+            f"ffprobe error: {err_msg}",
+            stderr=stderr_text,
+            returncode=e.returncode,
+            cmd=cmd,
+        ) from e
     except OSError as e:
         logger.error(f"ffprobe could not be executed: {e}")
-        raise FFmpegError(f"ffprobe could not be executed: {e}") from e
+        raise FFmpegError(f"ffprobe could not be executed: {e}", cmd=cmd) from e
     except (msgspec.DecodeError, msgspec.ValidationError) as e:
         logger.error(f"Failed to parse ffprobe output: {e}")
-        raise FFmpegError(f"ffprobe output parsing error: {e}") from e
+        raise FFmpegError(f"ffprobe output parsing error: {e}", cmd=cmd) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+"""Shared fixtures, including real-media fixtures for integration tests.
+
+Real ``.mkv`` files are downloaded into this directory by the Makefile
+(``make download``) from the same host pymkv uses for its fixtures. They are
+git-ignored. Integration tests skip automatically when the files — or the
+ffmpeg/ffprobe binaries — are absent, so the plain unit suite still runs
+anywhere with no setup.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import ffmpeg_wrap as ffmpeg
+
+TESTS_DIR = Path(__file__).parent
+REAL_FILE = TESTS_DIR / "file.mkv"
+REAL_FILE_TWO = TESTS_DIR / "file_2.mkv"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "integration: real-media tests that shell out to ffmpeg/ffprobe and need downloaded fixtures",
+    )
+
+
+@pytest.fixture(scope="session")
+def ffmpeg_available() -> None:
+    """Skip the test unless both ffmpeg and ffprobe are on PATH."""
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        pytest.skip("ffmpeg/ffprobe not installed")
+
+
+@pytest.fixture
+def real_file(ffmpeg_available: None) -> Path:
+    """Path to the primary real test file (video h264 + audio vorbis)."""
+    if not REAL_FILE.exists():
+        pytest.skip(f"{REAL_FILE} missing — run `make download` to fetch test media")
+    return REAL_FILE
+
+
+@pytest.fixture
+def real_file_two(ffmpeg_available: None) -> Path:
+    """Path to the secondary real test file (video h264 + audio vorbis)."""
+    if not REAL_FILE_TWO.exists():
+        pytest.skip(f"{REAL_FILE_TWO} missing — run `make download` to fetch test media")
+    return REAL_FILE_TWO
+
+
+@pytest.fixture
+def srt_file(tmp_path: Path) -> Path:
+    """A small valid SRT subtitle file for filter/burn-in tests."""
+    path = tmp_path / "subs.srt"
+    path.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\nHello world\n\n2\n00:00:01,000 --> 00:00:02,000\nSecond line\n\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def bad_media(tmp_path: Path) -> Path:
+    """A file with a media extension but garbage content (invalid to ffprobe)."""
+    path = tmp_path / "bad.mkv"
+    path.write_bytes(b"this is not a media file at all")
+    return path
+
+
+@pytest.fixture
+def mkv_with_subs(real_file: Path, srt_file: Path, tmp_path: Path) -> Path:
+    """A short Matroska muxed with a video, audio and a (text) subtitle stream."""
+    out = tmp_path / "with_subs.mkv"
+    (
+        ffmpeg.input(real_file, t=2)
+        .input(str(srt_file))
+        .output(str(out))
+        .map("0:v")
+        .map("0:a")
+        .map("1:s")
+        .codec("v", "copy")
+        .codec("a", "copy")
+        .codec("s", "srt")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    return out
+
+
+@pytest.fixture(scope="session")
+def subtitles_filter_available(ffmpeg_available: None) -> None:
+    """Skip unless this ffmpeg build has the ``subtitles`` filter (needs libass)."""
+    result = subprocess.run(
+        [shutil.which("ffmpeg") or "ffmpeg", "-hide_banner", "-filters"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if " subtitles " not in result.stdout:
+        pytest.skip("ffmpeg built without the subtitles filter (no libass)")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,3 +1,4 @@
+import io
 import os
 import subprocess
 from pathlib import Path
@@ -8,6 +9,7 @@ import pytest
 from ffmpeg_wrap._builder import FFmpeg, _convert_arg
 from ffmpeg_wrap._builder import input as ffmpeg_input
 from ffmpeg_wrap._errors import FFmpegError
+from ffmpeg_wrap._probe import Stream
 
 
 class TestFluentChain:
@@ -91,6 +93,33 @@ class TestGlobalArgs:
         assert cmd[2] == "-hide_banner"
 
 
+class TestGlobalSugar:
+    def test_hide_banner_emits_flag_in_global_slot(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").hide_banner()
+        cmd = ff.compile()
+        assert cmd == ["ffmpeg", "-hide_banner", "-i", "in.mkv", "out.mp4"]
+
+    def test_loglevel_emits_flag_and_value(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").loglevel("error")
+        cmd = ff.compile()
+        assert cmd == ["ffmpeg", "-loglevel", "error", "-i", "in.mkv", "out.mp4"]
+
+    def test_hide_banner_and_loglevel_compose_before_input(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").hide_banner().loglevel("verbose")
+        cmd = ff.compile()
+        assert cmd == ["ffmpeg", "-hide_banner", "-loglevel", "verbose", "-i", "in.mkv", "out.mp4"]
+        assert cmd.index("-hide_banner") < cmd.index("-i")
+        assert cmd.index("-loglevel") < cmd.index("-i")
+
+    def test_global_sugar_returns_self(self):
+        ff = FFmpeg()
+        assert ff.hide_banner() is ff
+        assert ff.loglevel("error") is ff
+
+
 class TestConvertArg:
     def test_true_value_produces_flag_only(self):
         assert _convert_arg("an", True) == ["-an"]
@@ -106,6 +135,396 @@ class TestConvertArg:
 
     def test_int_value_produces_flag_and_str_value(self):
         assert _convert_arg("t", 10) == ["-t", "10"]
+
+    def test_list_value_repeats_flag_per_element(self):
+        assert _convert_arg("map", ["0:v", "1:a"]) == ["-map", "0:v", "-map", "1:a"]
+
+    def test_tuple_value_repeats_flag_per_element(self):
+        assert _convert_arg("metadata", ("title=x", "comment=y")) == [
+            "-metadata",
+            "title=x",
+            "-metadata",
+            "comment=y",
+        ]
+
+    def test_empty_list_produces_nothing(self):
+        assert _convert_arg("map", []) == []
+
+
+class TestListValuedFlags:
+    def test_map_list_kwarg_repeats_flag(self):
+        ff = FFmpeg()
+        ff.input("a.mkv").input("b.mkv").output("out.mkv", map=["0:v", "1:a"], c="copy")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-i",
+            "a.mkv",
+            "-i",
+            "b.mkv",
+            "-map",
+            "0:v",
+            "-map",
+            "1:a",
+            "-c",
+            "copy",
+            "out.mkv",
+        ]
+
+    def test_metadata_list_kwarg_repeats_flag(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mkv", metadata=["title=Movie", "year=2026"])
+        assert ff.compile() == [
+            "ffmpeg",
+            "-i",
+            "in.mkv",
+            "-metadata",
+            "title=Movie",
+            "-metadata",
+            "year=2026",
+            "out.mkv",
+        ]
+
+    def test_mixing_list_and_scalar_kwargs_preserves_order(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mkv", map=["0:v", "0:a"], c="copy", crf=18)
+        cmd = ff.compile()
+        # list flag expands inline, scalar flags follow in insertion order
+        assert cmd == [
+            "ffmpeg",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:v",
+            "-map",
+            "0:a",
+            "-c",
+            "copy",
+            "-crf",
+            "18",
+            "out.mkv",
+        ]
+
+
+class TestMap:
+    def test_map_string_chains_to_repeated_flag(self):
+        ff = FFmpeg()
+        ff.input("a.mkv").input("b.mkv").output("out.mkv").map("0:v").map("1:a")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-i",
+            "a.mkv",
+            "-i",
+            "b.mkv",
+            "-map",
+            "0:v",
+            "-map",
+            "1:a",
+            "out.mkv",
+        ]
+
+    def test_map_variadic(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mkv").map("0:v", "0:a")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:v", "-map", "0:a", "out.mkv"]
+
+    def test_map_merges_with_existing_kwarg(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mkv", map="0:v").map("0:a")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:v", "-map", "0:a", "out.mkv"]
+
+    def test_map_stream_object_uses_per_type_specifier(self):
+        subtitle = Stream(index=2, codec_type="subtitle")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.srt").map(subtitle)
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:s:0", "out.srt"]
+
+    def test_map_stream_object_respects_type_index(self):
+        second_audio = Stream(index=3, codec_type="audio", type_index=1)
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mka").map(second_audio)
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:a:1", "out.mka"]
+
+    def test_map_stream_unknown_codec_type_falls_back_to_absolute(self):
+        unknown = Stream(index=4, codec_type=None)
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mkv").map(unknown)
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:4", "out.mkv"]
+
+    def test_map_mixes_stream_and_string(self):
+        video = Stream(index=0, codec_type="video")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mkv").map(video, "0:a")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:v:0", "-map", "0:a", "out.mkv"]
+
+    def test_map_stream_method(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.srt").map_stream("s", 0)
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-map", "0:s:0", "out.srt"]
+
+    def test_map_stream_method_custom_input(self):
+        ff = FFmpeg()
+        ff.input("a.mkv").input("b.mkv").output("out.mka").map_stream("a", 1, input=1)
+        assert ff.compile() == ["ffmpeg", "-i", "a.mkv", "-i", "b.mkv", "-map", "1:a:1", "out.mka"]
+
+    def test_map_before_output_raises(self):
+        ff = FFmpeg()
+        ff.input("in.mkv")
+        with pytest.raises(FFmpegError, match=r"call \.output"):
+            ff.map("0:v")
+
+
+class TestStreamSpecifiers:
+    def test_codec_emits_colon_flag(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").codec("v", "libx265")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-c:v", "libx265", "out.mp4"]
+
+    def test_bitrate_emits_colon_flag(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").bitrate("v", "2M")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-b:v", "2M", "out.mp4"]
+
+    def test_bitrate_accepts_int(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").bitrate("a", 128000)
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-b:a", "128000", "out.mp4"]
+
+    def test_quality_emits_colon_flag(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").quality("a", 2)
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-q:a", "2", "out.mp4"]
+
+    def test_audio_filter_emits_colon_flag(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").audio_filter("loudnorm")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-filter:a", "loudnorm", "out.mp4"]
+
+    def test_video_filter_emits_colon_flag(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").video_filter("scale=1280:-2")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-filter:v", "scale=1280:-2", "out.mp4"]
+
+    def test_multiple_kinds_coexist(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").codec("v", "libx265").codec("a", "aac").bitrate("v", "2M")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-i",
+            "in.mkv",
+            "-c:v",
+            "libx265",
+            "-c:a",
+            "aac",
+            "-b:v",
+            "2M",
+            "out.mp4",
+        ]
+
+    def test_composes_with_repeatable_map(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").map("0:v").map("0:a").codec("v", "libx265")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:v",
+            "-map",
+            "0:a",
+            "-c:v",
+            "libx265",
+            "out.mp4",
+        ]
+
+    def test_dict_unpack_escape_hatch_still_works(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4", **{"c:v:0": "libx264"})
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-c:v:0", "libx264", "out.mp4"]
+
+    def test_codec_before_output_raises(self):
+        ff = FFmpeg()
+        ff.input("in.mkv")
+        with pytest.raises(FFmpegError, match=r"call \.output"):
+            ff.codec("v", "libx265")
+
+
+class TestFlag:
+    def test_single_flag_emits_bare_token(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").flag("vn")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-vn", "out.mp4"]
+
+    def test_multiple_flags_in_one_call(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").flag("vn", "sn")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-vn", "-sn", "out.mp4"]
+
+    def test_chained_flag_calls(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").flag("vn").flag("sn")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-vn", "-sn", "out.mp4"]
+
+    def test_flag_ordering_relative_to_other_kwargs(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4", c="copy").flag("vn")
+        assert ff.compile() == ["ffmpeg", "-i", "in.mkv", "-c", "copy", "-vn", "out.mp4"]
+
+    def test_flag_composes_with_codec_and_map(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").map("0:a").codec("a", "aac").flag("vn")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-i",
+            "in.mkv",
+            "-map",
+            "0:a",
+            "-c:a",
+            "aac",
+            "-vn",
+            "out.mp4",
+        ]
+
+    def test_flag_before_output_raises(self):
+        ff = FFmpeg()
+        ff.input("in.mkv")
+        with pytest.raises(FFmpegError, match=r"call \.output"):
+            ff.flag("vn")
+
+    def test_contrast_none_kwarg_omits_but_flag_emits(self):
+        # output(..., vn=None) omits the switch entirely (no regression)...
+        omitted = FFmpeg()
+        omitted.input("in.mkv").output("out.mp4", vn=None)
+        assert omitted.compile() == ["ffmpeg", "-i", "in.mkv", "out.mp4"]
+        # ...while .flag("vn") is the intentional form that emits it.
+        emitted = FFmpeg()
+        emitted.input("in.mkv").output("out.mp4").flag("vn")
+        assert emitted.compile() == ["ffmpeg", "-i", "in.mkv", "-vn", "out.mp4"]
+
+
+class TestFilterComplex:
+    def test_filter_complex_after_global_before_input(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").hide_banner().filter_complex("[0:v]scale=1280:-2[v]")
+        cmd = ff.compile()
+        assert cmd == [
+            "ffmpeg",
+            "-hide_banner",
+            "-filter_complex",
+            "[0:v]scale=1280:-2[v]",
+            "-i",
+            "in.mkv",
+            "out.mp4",
+        ]
+        assert cmd.index("-hide_banner") < cmd.index("-filter_complex")
+        assert cmd.index("-filter_complex") < cmd.index("-i")
+
+    def test_filter_complex_without_global_args(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").filter_complex("[0:v]null[v]")
+        cmd = ff.compile()
+        assert cmd == ["ffmpeg", "-filter_complex", "[0:v]null[v]", "-i", "in.mkv", "out.mp4"]
+
+    def test_filter_complex_multi_output_with_map(self):
+        # Batch-trim shape: one graph fanned to multiple mapped outputs.
+        ff = FFmpeg()
+        ff.input("in.mkv").filter_complex("[0:v]split=2[a][b]")
+        ff.output("a.mp4").map("[a]")
+        ff.output("b.mp4").map("[b]")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-filter_complex",
+            "[0:v]split=2[a][b]",
+            "-i",
+            "in.mkv",
+            "-map",
+            "[a]",
+            "a.mp4",
+            "-map",
+            "[b]",
+            "b.mp4",
+        ]
+
+    def test_filter_complex_script_emits_script_form(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").filter_complex_script("graph.txt")
+        cmd = ff.compile()
+        assert cmd == [
+            "ffmpeg",
+            "-filter_complex_script",
+            "graph.txt",
+            "-i",
+            "in.mkv",
+            "out.mp4",
+        ]
+
+    def test_filter_complex_script_accepts_path_object(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").filter_complex_script(Path("graph.txt"))
+        cmd = ff.compile()
+        assert cmd[1] == "-filter_complex_script"
+        assert cmd[2] == "graph.txt"
+
+    def test_filter_complex_returns_self(self):
+        ff = FFmpeg()
+        assert ff.filter_complex("[0:v]null[v]") is ff
+        assert ff.filter_complex_script("graph.txt") is ff
+
+    def test_filter_complex_last_call_wins(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4").filter_complex("[0:v]a[v]").filter_complex_script("g.txt")
+        cmd = ff.compile()
+        assert "-filter_complex" not in cmd
+        assert cmd[1] == "-filter_complex_script"
+        assert cmd[2] == "g.txt"
+
+
+class TestHwaccel:
+    def test_hwaccel_lands_before_input(self):
+        ff = FFmpeg()
+        ff.input("in.mkv").hwaccel("cuda").output("out.mp4", c="copy")
+        cmd = ff.compile()
+        assert cmd == [
+            "ffmpeg",
+            "-hwaccel",
+            "cuda",
+            "-i",
+            "in.mkv",
+            "-c",
+            "copy",
+            "out.mp4",
+        ]
+        assert cmd.index("-hwaccel") < cmd.index("-i")
+
+    def test_hwaccel_equivalent_to_input_kwarg(self):
+        sugar = FFmpeg().input("in.mkv").hwaccel("cuda").output("out.mp4")
+        kwarg = FFmpeg().input("in.mkv", hwaccel="cuda").output("out.mp4")
+        assert sugar.compile() == kwarg.compile()
+
+    def test_hwaccel_targets_current_input(self):
+        ff = FFmpeg()
+        ff.input("a.mkv").hwaccel("cuda").input("b.mkv").hwaccel("vaapi")
+        ff.output("out.mp4")
+        assert ff.compile() == [
+            "ffmpeg",
+            "-hwaccel",
+            "cuda",
+            "-i",
+            "a.mkv",
+            "-hwaccel",
+            "vaapi",
+            "-i",
+            "b.mkv",
+            "out.mp4",
+        ]
+
+    def test_hwaccel_returns_self(self):
+        ff = FFmpeg().input("in.mkv")
+        assert ff.hwaccel("cuda") is ff
+
+    def test_hwaccel_before_input_raises(self):
+        ff = FFmpeg()
+        with pytest.raises(FFmpegError):
+            ff.hwaccel("cuda")
 
 
 class TestInputHelper:
@@ -126,34 +545,51 @@ class TestInputHelper:
         assert result.compile()[0] == "/usr/local/bin/ffmpeg"
 
 
+def _popen_cm(returncode=0, stderr=b"", stdout=None):
+    """Build a MagicMock standing in for ``subprocess.Popen`` used as a
+    context manager by ``FFmpeg._run_tee`` (the non-capture-stderr path).
+
+    The child always runs in binary mode, so stderr/stdout are byte streams."""
+    process = MagicMock()
+    process.stderr = io.BytesIO(stderr)
+    process.stdout = io.BytesIO(stdout) if stdout is not None else None
+    process.returncode = returncode
+    process.wait = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = process
+    cm.__exit__.return_value = False
+    return cm
+
+
 class TestRun:
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_executes_command(self, mock_run):
-        mock_run.return_value = MagicMock(stdout=None, stderr=None)
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_executes_command(self, mock_popen):
+        mock_popen.return_value = _popen_cm()
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4", c="copy").run()
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args
-        cmd = call_args[0][0]
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
         assert cmd == ["ffmpeg", "-i", "in.mkv", "-c", "copy", "out.mp4"]
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_raises_ffmpeg_error_on_failure(self, mock_run):
-        mock_run.side_effect = subprocess.CalledProcessError(1, "ffmpeg", stderr=b"encoding failed")
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_raises_ffmpeg_error_on_failure(self, mock_popen):
+        mock_popen.return_value = _popen_cm(returncode=1, stderr=b"encoding failed")
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4")
         with pytest.raises(FFmpegError, match="ffmpeg error"):
             ff.run()
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_capture_stdout(self, mock_run):
-        mock_run.return_value = MagicMock(stdout=b"output data", stderr=None)
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_capture_stdout(self, mock_popen):
+        mock_popen.return_value = _popen_cm(stdout=b"output data")
         ff = FFmpeg()
         ff.input("in.mkv").output("pipe:", f="rawvideo")
         ff.run(capture_stdout=True)
-        call_args = mock_run.call_args
+        call_args = mock_popen.call_args
         assert call_args[1]["stdout"] == subprocess.PIPE
-        assert call_args[1]["stderr"] is None
+        # stderr is piped internally (and teed to the terminal) so the failure
+        # path can populate FFmpegError.stderr even without capture.
+        assert call_args[1]["stderr"] == subprocess.PIPE
 
     @patch("ffmpeg_wrap._builder.subprocess.run")
     def test_run_capture_stderr(self, mock_run):
@@ -165,17 +601,17 @@ class TestRun:
         assert call_args[1]["stdout"] is None
         assert call_args[1]["stderr"] == subprocess.PIPE
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_error_without_stderr(self, mock_run):
-        mock_run.side_effect = subprocess.CalledProcessError(1, "ffmpeg", stderr=None)
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_error_without_stderr(self, mock_popen):
+        mock_popen.return_value = _popen_cm(returncode=1, stderr=b"")
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4")
         with pytest.raises(FFmpegError):
             ff.run()
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_returns_none_when_not_capturing(self, mock_run):
-        mock_run.return_value = MagicMock(stdout=None, stderr=None)
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_returns_none_when_not_capturing(self, mock_popen):
+        mock_popen.return_value = _popen_cm()
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4")
         stdout, stderr = ff.run()
@@ -201,29 +637,211 @@ class TestRun:
         assert call_args[1]["stdout"] == subprocess.PIPE
         assert call_args[1]["stderr"] == subprocess.PIPE
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_raises_ffmpeg_error_on_missing_binary(self, mock_run):
-        mock_run.side_effect = FileNotFoundError("No such file or directory: 'ffmpeg'")
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_raises_ffmpeg_error_on_missing_binary(self, mock_popen):
+        mock_popen.side_effect = FileNotFoundError("No such file or directory: 'ffmpeg'")
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4")
         with pytest.raises(FFmpegError, match="ffmpeg could not be executed"):
             ff.run()
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_raises_ffmpeg_error_on_bad_ffmpeg_path(self, mock_run):
-        mock_run.side_effect = FileNotFoundError("No such file or directory: '/bad/path/ffmpeg'")
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_raises_ffmpeg_error_on_bad_ffmpeg_path(self, mock_popen):
+        mock_popen.side_effect = FileNotFoundError("No such file or directory: '/bad/path/ffmpeg'")
         ff = FFmpeg(ffmpeg_path="/bad/path/ffmpeg")
         ff.input("in.mkv").output("out.mp4")
         with pytest.raises(FFmpegError, match="ffmpeg could not be executed"):
             ff.run()
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_raises_ffmpeg_error_on_permission_error(self, mock_run):
-        mock_run.side_effect = PermissionError("[Errno 13] Permission denied: '/usr/bin/ffmpeg'")
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_raises_ffmpeg_error_on_permission_error(self, mock_popen):
+        mock_popen.side_effect = PermissionError("[Errno 13] Permission denied: '/usr/bin/ffmpeg'")
         ff = FFmpeg()
         ff.input("in.mkv").output("out.mp4")
         with pytest.raises(FFmpegError, match="ffmpeg could not be executed"):
             ff.run()
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_failure_populates_structured_error(self, mock_popen):
+        mock_popen.return_value = _popen_cm(returncode=2, stderr=b"encoding failed")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with pytest.raises(FFmpegError) as exc_info:
+            ff.run()
+        err = exc_info.value
+        assert err.returncode == 2
+        assert err.stderr == "encoding failed"
+        assert err.cmd == ["ffmpeg", "-i", "in.mkv", "out.mp4"]
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_failure_populates_stderr_even_without_capture(self, mock_popen):
+        mock_popen.return_value = _popen_cm(returncode=1, stderr=b"boom")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with pytest.raises(FFmpegError) as exc_info:
+            ff.run(capture_stderr=False)
+        assert exc_info.value.stderr == "boom"
+
+    @patch("ffmpeg_wrap._builder.subprocess.run")
+    def test_run_failure_without_stderr_leaves_attr_none(self, mock_run):
+        # Defensive guard: when CalledProcessError.stderr is None (e.g. stderr
+        # was not piped), FFmpegError.stderr stays None. Exercised via the
+        # capture path where subprocess.run surfaces the exception directly.
+        mock_run.side_effect = subprocess.CalledProcessError(1, "ffmpeg", stderr=None)
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with pytest.raises(FFmpegError) as exc_info:
+            ff.run(capture_stderr=True)
+        assert exc_info.value.stderr is None
+        assert exc_info.value.returncode == 1
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_oserror_populates_cmd_only(self, mock_popen):
+        mock_popen.side_effect = FileNotFoundError("No such file or directory: 'ffmpeg'")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with pytest.raises(FFmpegError) as exc_info:
+            ff.run()
+        err = exc_info.value
+        assert err.cmd == ["ffmpeg", "-i", "in.mkv", "out.mp4"]
+        assert err.returncode is None
+        assert err.stderr is None
+
+    @patch("ffmpeg_wrap._builder.subprocess.run")
+    def test_run_text_false_by_default_passes_text_false(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=b"out", stderr=b"err")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        stdout, stderr = ff.run(capture_stdout=True, capture_stderr=True)
+        assert mock_run.call_args[1]["text"] is False
+        assert stdout == b"out"
+        assert stderr == b"err"
+
+    @patch("ffmpeg_wrap._builder.subprocess.run")
+    def test_run_text_true_returns_str(self, mock_run):
+        mock_run.return_value = MagicMock(stdout="out", stderr="err")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        stdout, stderr = ff.run(capture_stdout=True, capture_stderr=True, text=True)
+        assert mock_run.call_args[1]["text"] is True
+        assert stdout == "out"
+        assert stderr == "err"
+
+    @patch("ffmpeg_wrap._builder.sys.stderr")
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_tees_stderr_to_terminal_on_success(self, mock_popen, mock_stderr):
+        # On a successful bare run(), ffmpeg's stderr must still reach the
+        # terminal (live progress) while not being returned to the caller.
+        mock_popen.return_value = _popen_cm(returncode=0, stderr=b"frame= 10\n")
+        sink = mock_stderr.buffer
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        stdout, stderr = ff.run()
+        assert stdout is None
+        assert stderr is None
+        # stderr content was forwarded to the inherited stderr stream.
+        written = b"".join(call.args[0] for call in sink.write.call_args_list)
+        assert written == b"frame= 10\n"
+
+    @patch("ffmpeg_wrap._builder.sys.stderr")
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_streams_carriage_return_progress_live(self, mock_popen, mock_stderr):
+        # ffmpeg writes progress as `\r`-terminated updates with no newline
+        # until the very end. A line-oriented read would withhold them until
+        # EOF; chunked reads must forward each update as it arrives.
+        progress = [b"frame=  1 q=28.0 \r", b"frame=  2 q=27.0 \r", b"frame=  3\n"]
+
+        class _ChunkStream:
+            def __init__(self, chunks):
+                self._chunks = list(chunks)
+
+            def read1(self, _size):
+                return self._chunks.pop(0) if self._chunks else b""
+
+            def close(self):
+                pass
+
+        process = MagicMock()
+        process.stderr = _ChunkStream(progress)
+        process.stdout = None
+        process.returncode = 0
+        cm = MagicMock()
+        cm.__enter__.return_value = process
+        cm.__exit__.return_value = False
+        mock_popen.return_value = cm
+        sink = mock_stderr.buffer
+
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        ff.run()
+
+        writes = [call.args[0] for call in sink.write.call_args_list]
+        # Each `\r` update reached the terminal as its own write (live), and
+        # the full content was forwarded.
+        assert writes == progress
+        assert b"".join(writes) == b"".join(progress)
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_text_true_failure_keeps_str_stderr(self, mock_popen):
+        # text=True decodes the captured byte stderr to str for FFmpegError.
+        mock_popen.return_value = _popen_cm(returncode=1, stderr=b"boom text")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with pytest.raises(FFmpegError) as exc_info:
+            ff.run(text=True)
+        assert exc_info.value.stderr == "boom text"
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_text_true_normalizes_newlines_like_subprocess(self, mock_popen):
+        # text=True must mirror subprocess.run(text=True) universal-newline
+        # translation: CRLF and bare CR collapse to LF in returned stdout and
+        # in FFmpegError.stderr (the tee path decodes manually).
+        mock_popen.return_value = _popen_cm(returncode=1, stderr=b"line1\r\nline2\rline3\n", stdout=b"a\r\nb\rc")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("pipe:", f="rawvideo")
+        with pytest.raises(FFmpegError) as exc_info:
+            ff.run(capture_stdout=True, text=True)
+        assert exc_info.value.stderr == "line1\nline2\nline3\n"
+        assert exc_info.value.cmd is not None
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_text_true_success_normalizes_stdout_newlines(self, mock_popen):
+        mock_popen.return_value = _popen_cm(returncode=0, stdout=b"a\r\nb\rc")
+        ff = FFmpeg()
+        ff.input("in.mkv").output("pipe:", f="rawvideo")
+        stdout, stderr = ff.run(capture_stdout=True, text=True)
+        assert stdout == "a\nb\nc"
+        assert stderr is None
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_tees_to_text_only_stderr_without_buffer(self, mock_popen):
+        # Some environments replace sys.stderr with a text-only wrapper that
+        # has no .buffer (and rejects bytes). The tee must still forward the
+        # live progress by decoding per chunk instead of silently dropping it.
+        mock_popen.return_value = _popen_cm(returncode=0, stderr=b"frame= 10\r")
+
+        class _TextOnlyStderr:
+            def __init__(self):
+                self.written = []
+
+            def write(self, data):
+                if not isinstance(data, str):
+                    raise TypeError("write() argument must be str, not bytes")
+                self.written.append(data)
+
+            def flush(self):
+                pass
+
+        fake_stderr = _TextOnlyStderr()
+        ff = FFmpeg()
+        ff.input("in.mkv").output("out.mp4")
+        with patch("ffmpeg_wrap._builder.sys.stderr", fake_stderr):
+            stdout, stderr = ff.run()
+        assert stdout is None
+        assert stderr is None
+        # Live progress reached the text-only sink as decoded str (CR preserved
+        # so the terminal can overwrite in place).
+        assert "".join(fake_stderr.written) == "frame= 10\r"
 
 
 class TestPathLikeSupport:
@@ -245,13 +863,13 @@ class TestPathLikeSupport:
         cmd = ff.compile()
         assert cmd == ["ffmpeg", "-i", "in.mkv", "-c", "copy", "out.mp4"]
 
-    @patch("ffmpeg_wrap._builder.subprocess.run")
-    def test_run_with_path_objects_does_not_crash(self, mock_run):
-        mock_run.return_value = MagicMock(stdout=None, stderr=None)
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_with_path_objects_does_not_crash(self, mock_popen):
+        mock_popen.return_value = _popen_cm()
         ff = FFmpeg()
         ff.input(Path("in.mkv")).output(Path("out.mp4"))
         ff.run()
-        mock_run.assert_called_once()
+        mock_popen.assert_called_once()
 
     def test_input_accepts_custom_pathlike(self):
         class MyPath(os.PathLike):

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,0 +1,118 @@
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ffmpeg_wrap._encoders import (
+    _clear_encoders_cache,
+    _parse_encoders,
+    encoders,
+    has_encoder,
+)
+from ffmpeg_wrap._errors import FFmpegError
+
+# A trimmed but faithful capture of ``ffmpeg -hide_banner -encoders`` output.
+ENCODERS_FIXTURE = """\
+Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ .F.... = Frame-level multithreading
+ ..S... = Slice-level multithreading
+ ...X.. = Codec is experimental
+ ....B. = Supports draw_horiz_band
+ .....D = Supports direct rendering method 1
+ ------
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC (codec h264)
+ V....D libx265              libx265 H.265 / HEVC (codec hevc)
+ V..... h264_nvenc           NVIDIA NVENC H.264 encoder (codec h264)
+ V..... hevc_nvenc           NVIDIA NVENC hevc encoder (codec hevc)
+ A....D aac                  AAC (Advanced Audio Coding)
+ A..... libmp3lame           libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
+ S..... srt                  SubRip subtitle (codec subrip)
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _clear_encoders_cache()
+    yield
+    _clear_encoders_cache()
+
+
+class TestParseEncoders:
+    def test_extracts_names_after_separator(self):
+        names = _parse_encoders(ENCODERS_FIXTURE)
+        assert names == frozenset({"libx264", "libx265", "h264_nvenc", "hevc_nvenc", "aac", "libmp3lame", "srt"})
+
+    def test_ignores_legend_before_separator(self):
+        # "Video"/"Audio" legend descriptions must not leak in as encoder names.
+        names = _parse_encoders(ENCODERS_FIXTURE)
+        assert "Video" not in names
+        assert "=" not in names
+
+    def test_empty_output(self):
+        assert _parse_encoders("") == frozenset()
+
+
+class TestEncoders:
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_encoders_parses_fixture(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=ENCODERS_FIXTURE)
+        result = encoders()
+        assert "h264_nvenc" in result
+        assert "libx264" in result
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["ffmpeg", "-hide_banner", "-encoders"]
+        assert mock_run.call_args[1]["text"] is True
+
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_result_is_cached_per_path(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=ENCODERS_FIXTURE)
+        encoders("ffmpeg")
+        encoders("ffmpeg")
+        assert mock_run.call_count == 1
+        # A different path triggers a fresh probe (separate cache key).
+        encoders("/opt/ffmpeg/bin/ffmpeg")
+        assert mock_run.call_count == 2
+
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_clear_cache_forces_reprobe(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=ENCODERS_FIXTURE)
+        encoders()
+        _clear_encoders_cache()
+        encoders()
+        assert mock_run.call_count == 2
+
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_raises_on_called_process_error(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, "ffmpeg", stderr="boom")
+        with pytest.raises(FFmpegError) as exc:
+            encoders()
+        assert exc.value.returncode == 1
+        assert exc.value.stderr == "boom"
+
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_raises_on_missing_binary(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("no ffmpeg")
+        with pytest.raises(FFmpegError):
+            encoders("/nonexistent/ffmpeg")
+
+
+class TestHasEncoder:
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_true_for_present_encoder(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=ENCODERS_FIXTURE)
+        assert has_encoder("h264_nvenc") is True
+
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_false_for_absent_encoder(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=ENCODERS_FIXTURE)
+        assert has_encoder("nonexistent_codec") is False
+
+    @patch("ffmpeg_wrap._encoders.subprocess.run")
+    def test_uses_cache(self, mock_run):
+        mock_run.return_value = MagicMock(stdout=ENCODERS_FIXTURE)
+        has_encoder("libx264")
+        has_encoder("aac")
+        assert mock_run.call_count == 1

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -23,3 +23,28 @@ def test_ffmpeg_error_preserves_cause():
         raise FFmpegError("wrapper error") from cause
     except FFmpegError as exc:
         assert exc.__cause__ is cause
+
+
+def test_ffmpeg_error_default_attrs_are_none():
+    err = FFmpegError("boom")
+    assert err.stderr is None
+    assert err.returncode is None
+    assert err.cmd is None
+
+
+def test_ffmpeg_error_carries_structured_attrs():
+    err = FFmpegError(
+        "ffmpeg error: failed",
+        stderr="failed",
+        returncode=1,
+        cmd=["ffmpeg", "-i", "in.mkv", "out.mp4"],
+    )
+    assert err.stderr == "failed"
+    assert err.returncode == 1
+    assert err.cmd == ["ffmpeg", "-i", "in.mkv", "out.mp4"]
+
+
+def test_ffmpeg_error_str_unchanged_with_structured_attrs():
+    err = FFmpegError("ffmpeg error: failed", stderr="failed", returncode=1)
+    assert str(err) == "ffmpeg error: failed"
+    assert err.args[0] == "ffmpeg error: failed"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,34 @@
+r"""Tests for the ``filter_arg_escape`` filtergraph escaping utility."""
+
+from ffmpeg_wrap import filter_arg_escape
+
+
+class TestFilterArgEscape:
+    def test_plain_path_only_wrapped(self):
+        # No special characters: just single-quote wrapping.
+        assert filter_arg_escape("/videos/clip.srt") == "'/videos/clip.srt'"
+
+    def test_windows_drive_path(self):
+        # The drive-letter colon must be escaped for the filter-option parser
+        # (otherwise ffmpeg splits the path there) and backslashes doubled.
+        assert filter_arg_escape(r"C:\videos\clip.srt") == r"'C\:\\videos\\clip.srt'"
+
+    def test_colon_in_filename(self):
+        # A bare colon would be read as an option separator, so it is escaped.
+        assert filter_arg_escape("/tmp/12:30 show.srt") == r"'/tmp/12\:30 show.srt'"
+
+    def test_embedded_single_quote(self):
+        # ' is special at both levels: backslash-escaped for the option parser
+        # (\') and emitted via the close/escape/reopen idiom ('\'') for the
+        # filtergraph parser.
+        assert filter_arg_escape("it's a clip.srt") == "'it\\'\\''s a clip.srt'"
+
+    def test_backslash_and_colon_escaped(self):
+        # A literal backslash is doubled and the colon escaped for the
+        # filter-option parser.
+        assert filter_arg_escape("a\\b:c") == r"'a\\b\:c'"
+
+    def test_roundtrips_into_subtitles_filter(self):
+        path = r"C:\subs\ru.srt"
+        graph = f"subtitles={filter_arg_escape(path)}"
+        assert graph == r"subtitles='C\:\\subs\\ru.srt'"

--- a/tests/test_integration_real_media.py
+++ b/tests/test_integration_real_media.py
@@ -1,0 +1,398 @@
+"""End-to-end tests against real media files.
+
+These exercise the full path — build a command, actually run ffmpeg/ffprobe,
+then re-probe the output to confirm the result — rather than asserting argv.
+They cover the 0.3.0 surface (repeatable/typed ``map()``, codec helpers,
+``filter_complex``, structured ``FFmpegError``, ``run(text=True)``, encoder
+introspection) on genuine streams.
+
+Source files (`real_file`/`real_file_two` fixtures) are both Matroska with a
+single h264 video stream and a single Vorbis audio stream. Re-encoding tests
+trim with ``t=`` to stay fast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import ffmpeg_wrap as ffmpeg
+
+pytestmark = pytest.mark.integration
+
+
+def test_probe_real_file_format_and_streams(real_file: Path) -> None:
+    result = ffmpeg.probe(real_file)
+
+    assert result.format is not None
+    assert "matroska" in (result.format.format_name or "")
+    assert result.duration_seconds() == pytest.approx(183.129, abs=0.5)
+    assert result.format.duration_seconds() == pytest.approx(183.129, abs=0.5)
+
+    assert len(result.streams) == 2
+    video = next(s for s in result.streams if s.is_video)
+    audio = next(s for s in result.streams if s.is_audio)
+    assert video.codec_name == "h264"
+    assert audio.codec_name == "vorbis"
+    assert audio.channels == 2
+
+
+def test_probe_predicates_are_mutually_consistent(real_file: Path) -> None:
+    for stream in ffmpeg.probe(real_file).streams:
+        assert stream.is_video is (stream.codec_type == "video")
+        assert stream.is_audio is (stream.codec_type == "audio")
+        assert stream.is_text_subtitle is False
+        assert stream.is_image_subtitle is False
+
+
+def test_validate_real_file_is_clean(real_file: Path) -> None:
+    ok, stderr = ffmpeg.validate(real_file)
+    assert ok is True, f"expected clean validation, got stderr: {stderr!r}"
+
+
+def test_copy_remux_preserves_streams(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "copy.mkv"
+    ffmpeg.input(real_file, t=2).output(str(out), c="copy").overwrite_output().run(capture_stderr=True)
+
+    streams = ffmpeg.probe(out).streams
+    kinds = sorted(s.codec_type for s in streams)
+    assert kinds == ["audio", "video"]
+
+
+def test_extract_audio_with_map_and_codec(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "audio.wav"
+    (
+        ffmpeg.input(real_file, t=2)
+        .output(str(out))
+        .map("0:a")
+        .codec("a", "pcm_s16le")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+
+    streams = ffmpeg.probe(out).streams
+    assert all(s.is_audio for s in streams)
+    assert streams[0].codec_name == "pcm_s16le"
+
+
+def test_repeatable_map_chained_combines_two_inputs(real_file: Path, real_file_two: Path, tmp_path: Path) -> None:
+    """Video from input 0, audio from input 1 via two chained .map() calls."""
+    out = tmp_path / "mux_chained.mkv"
+    (
+        ffmpeg.input(real_file)
+        .input(real_file_two)
+        .output(str(out))
+        .map("0:v")
+        .map("1:a")
+        .codec("v", "copy")
+        .codec("a", "copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+
+    streams = ffmpeg.probe(out).streams
+    assert [(s.codec_type, s.codec_name) for s in streams] == [("video", "h264"), ("audio", "vorbis")]
+
+
+def test_repeatable_map_list_value_combines_two_inputs(real_file: Path, real_file_two: Path, tmp_path: Path) -> None:
+    """Same result via a list-valued map= kwarg instead of chained calls."""
+    out = tmp_path / "mux_list.mkv"
+    (
+        ffmpeg.input(real_file)
+        .input(real_file_two)
+        .output(str(out), map=["0:v", "1:a"], c="copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+
+    streams = ffmpeg.probe(out).streams
+    assert sorted(s.codec_type for s in streams) == ["audio", "video"]
+
+
+def test_map_stream_object_emits_per_type_specifier(real_file: Path, tmp_path: Path) -> None:
+    """A probed Stream maps to its per-type specifier (0:a:0), not its absolute index."""
+    audio = next(s for s in ffmpeg.probe(real_file).streams if s.is_audio)
+    out = tmp_path / "by_stream.mkv"
+    (
+        ffmpeg.input(real_file, t=2)
+        .output(str(out))
+        .map(audio)
+        .codec("a", "copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+
+    streams = ffmpeg.probe(out).streams
+    assert all(s.is_audio for s in streams)
+
+
+def test_filter_complex_scales_video(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "scaled.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .filter_complex("[0:v]scale=320:-2[v]")
+        .output(str(out))
+        .map("[v]")
+        .map("0:a")
+        .codec("a", "copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+
+    video = next(s for s in ffmpeg.probe(out).streams if s.is_video)
+    assert video.width == 320
+
+
+def test_failed_run_raises_structured_error(ffmpeg_available: None, tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.mkv"
+    out = tmp_path / "out.mkv"
+
+    with pytest.raises(ffmpeg.FFmpegError) as excinfo:
+        ffmpeg.input(str(missing)).output(str(out)).overwrite_output().run()
+
+    err = excinfo.value
+    assert err.returncode is not None and err.returncode != 0
+    assert err.cmd is not None and err.cmd[0] == "ffmpeg"
+    assert err.stderr and "does_not_exist" in err.stderr
+
+
+def test_run_text_mode_returns_str_stderr(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "text.mkv"
+    _stdout, stderr = (
+        ffmpeg.input(real_file, t=1).output(str(out), c="copy").overwrite_output().run(capture_stderr=True, text=True)
+    )
+    assert isinstance(stderr, str)
+
+
+def test_encoders_introspection_reflects_real_build(ffmpeg_available: None) -> None:
+    available = ffmpeg.encoders()
+    assert isinstance(available, frozenset)
+    assert len(available) > 0
+    assert "aac" in available
+    assert ffmpeg.has_encoder("aac") is True
+    assert ffmpeg.has_encoder("definitely_not_a_real_encoder") is False
+
+
+def test_subtitle_stream_predicates(mkv_with_subs: Path) -> None:
+    streams = ffmpeg.probe(mkv_with_subs).streams
+    subtitle = next(s for s in streams if s.is_subtitle)
+    assert subtitle.codec_name == "subrip"
+    assert subtitle.is_text_subtitle is True
+    assert subtitle.is_image_subtitle is False
+    assert sum(s.is_subtitle for s in streams) == 1
+
+
+def test_stream_map_specifier_and_type_index(mkv_with_subs: Path) -> None:
+    by_kind = {s.codec_type: s for s in ffmpeg.probe(mkv_with_subs).streams}
+    assert by_kind["video"].map_specifier() == "0:v:0"
+    assert by_kind["audio"].map_specifier() == "0:a:0"
+    assert by_kind["subtitle"].map_specifier() == "0:s:0"
+    assert by_kind["subtitle"].map_specifier(input_index=1) == "1:s:0"
+    assert all(s.type_index == 0 for s in by_kind.values())
+
+
+def test_codec_type_enum_matches_probe_strings(mkv_with_subs: Path) -> None:
+    kinds = {s.codec_type for s in ffmpeg.probe(mkv_with_subs).streams}
+    assert ffmpeg.CodecType.VIDEO in kinds
+    assert ffmpeg.CodecType.AUDIO in kinds
+    assert ffmpeg.CodecType.SUBTITLE in kinds
+
+
+def test_validate_rejects_bad_media(bad_media: Path, ffmpeg_available: None) -> None:
+    ok, stderr = ffmpeg.validate(bad_media)
+    assert ok is False
+    assert stderr.strip() != ""
+
+
+def test_validate_invalid_loglevel_raises(real_file: Path) -> None:
+    with pytest.raises(ValueError, match="invalid loglevel"):
+        ffmpeg.validate(real_file, loglevel="definitely-not-a-level")
+
+
+def test_validate_forwards_extra_args(real_file: Path) -> None:
+    ok, _stderr = ffmpeg.validate(real_file, extra_args=("-show_format",))
+    assert ok is True
+
+
+def test_probe_bad_media_raises_structured_error(bad_media: Path, ffmpeg_available: None) -> None:
+    with pytest.raises(ffmpeg.FFmpegError) as excinfo:
+        ffmpeg.probe(bad_media)
+    assert excinfo.value.returncode is not None and excinfo.value.returncode != 0
+
+
+def test_map_stream_selects_audio(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "by_map_stream.mkv"
+    (
+        ffmpeg.input(real_file, t=2)
+        .output(str(out))
+        .map_stream("a", 0)
+        .codec("a", "copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    assert all(s.is_audio for s in ffmpeg.probe(out).streams)
+
+
+def test_bitrate_helper_sets_audio_bitrate(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "bitrate.m4a"
+    (
+        ffmpeg.input(real_file, t=1)
+        .output(str(out))
+        .map("0:a")
+        .codec("a", "aac")
+        .bitrate("a", "96k")
+        .flag("vn")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    streams = ffmpeg.probe(out).streams
+    assert [s.codec_name for s in streams] == ["aac"]
+
+
+def test_quality_helper_encodes_audio(real_file: Path, tmp_path: Path) -> None:
+    if not ffmpeg.has_encoder("libvorbis"):
+        pytest.skip("libvorbis not available in this ffmpeg build")
+    out = tmp_path / "quality.ogg"
+    (
+        ffmpeg.input(real_file, t=1)
+        .output(str(out))
+        .map("0:a")
+        .codec("a", "libvorbis")
+        .quality("a", 3)
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    assert [s.codec_name for s in ffmpeg.probe(out).streams] == ["vorbis"]
+
+
+def test_audio_filter_changes_duration(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "atempo.wav"
+    (
+        ffmpeg.input(real_file, t=2)
+        .output(str(out))
+        .map("0:a")
+        .audio_filter("atempo=2.0")
+        .codec("a", "pcm_s16le")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    assert ffmpeg.probe(out).duration_seconds() == pytest.approx(1.0, abs=0.2)
+
+
+def test_video_filter_scales_video(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "vf.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .output(str(out))
+        .video_filter("scale=176:-2")
+        .map("0:v")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    video = next(s for s in ffmpeg.probe(out).streams if s.is_video)
+    assert video.width == 176
+
+
+def test_flag_vn_drops_video(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "audio_only.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .output(str(out))
+        .flag("vn")
+        .codec("a", "copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    streams = ffmpeg.probe(out).streams
+    assert all(not s.is_video for s in streams)
+    assert any(s.is_audio for s in streams)
+
+
+def test_loglevel_hide_banner_and_global_args(real_file: Path, tmp_path: Path) -> None:
+    out = tmp_path / "quiet.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .output(str(out), c="copy")
+        .loglevel("error")
+        .hide_banner()
+        .global_args("-nostats")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    assert len(ffmpeg.probe(out).streams) == 2
+
+
+def test_filter_complex_script_scales_video(real_file: Path, tmp_path: Path) -> None:
+    script = tmp_path / "graph.txt"
+    script.write_text("[0:v]scale=160:-2[v]", encoding="utf-8")
+    out = tmp_path / "fcs.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .filter_complex_script(str(script))
+        .output(str(out))
+        .map("[v]")
+        .map("0:a")
+        .codec("a", "copy")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    video = next(s for s in ffmpeg.probe(out).streams if s.is_video)
+    assert video.width == 160
+
+
+def test_capture_stdout_pipe(real_file: Path) -> None:
+    stdout, _stderr = (
+        ffmpeg.input(real_file, t=1)
+        .output("pipe:1", f="wav", acodec="pcm_s16le")
+        .map("0:a")
+        .overwrite_output()
+        .run(capture_stdout=True)
+    )
+    assert isinstance(stdout, bytes)
+    assert stdout[:4] == b"RIFF"
+
+
+def test_hwaccel_input_flag_runs(real_file: Path, tmp_path: Path) -> None:
+    """`.hwaccel("auto")` emits the input-side flag; ffmpeg falls back to CPU when no GPU."""
+    out = tmp_path / "hwaccel.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .hwaccel("auto")
+        .output(str(out), c="copy")
+        .map("0:v")
+        .map("0:a")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    assert len(ffmpeg.probe(out).streams) == 2
+
+
+def test_lavfi_only_input_generates_silence(ffmpeg_available: None, tmp_path: Path) -> None:
+    """The documented lavfi idiom: a source with no -i input file."""
+    out = tmp_path / "silence.wav"
+    (
+        ffmpeg.input("anullsrc=channel_layout=stereo:sample_rate=48000", f="lavfi", t=1)
+        .output(str(out))
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    result = ffmpeg.probe(out)
+    assert result.duration_seconds() == pytest.approx(1.0, abs=0.1)
+    assert any(s.is_audio for s in result.streams)
+
+
+def test_filter_arg_escape_burn_in(
+    real_file: Path, srt_file: Path, subtitles_filter_available: None, tmp_path: Path
+) -> None:
+    """filter_arg_escape feeds a path into the subtitles filter, burned into video."""
+    out = tmp_path / "burned.mkv"
+    (
+        ffmpeg.input(real_file, t=1)
+        .output(str(out))
+        .video_filter(f"subtitles={ffmpeg.filter_arg_escape(str(srt_file))}")
+        .map("0:v")
+        .overwrite_output()
+        .run(capture_stderr=True)
+    )
+    assert any(s.is_video for s in ffmpeg.probe(out).streams)

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import subprocess
 from pathlib import Path
@@ -8,7 +7,7 @@ import msgspec
 import pytest
 
 from ffmpeg_wrap._errors import FFmpegError
-from ffmpeg_wrap._probe import Format, ProbeResult, Stream, _resolve_input, probe, validate
+from ffmpeg_wrap._probe import CodecType, Format, ProbeResult, Stream, _resolve_input, probe, validate
 
 
 class TestResolveInput:
@@ -87,6 +86,110 @@ class TestStream:
         assert stream.width is None
         assert stream.height is None
         assert stream.tags is None
+        assert stream.type_index == 0
+
+    def test_map_specifier_per_type(self):
+        assert Stream(index=0, codec_type="video").map_specifier() == "0:v:0"
+        assert Stream(index=2, codec_type="subtitle").map_specifier() == "0:s:0"
+        assert Stream(index=3, codec_type="audio", type_index=1).map_specifier() == "0:a:1"
+
+    def test_map_specifier_custom_input(self):
+        assert Stream(index=0, codec_type="audio").map_specifier(input_index=1) == "1:a:0"
+
+    def test_map_specifier_unknown_codec_type_uses_absolute_index(self):
+        assert Stream(index=4, codec_type=None).map_specifier() == "0:4"
+        assert Stream(index=5, codec_type="exotic").map_specifier() == "0:5"
+
+    def test_duration_seconds_numeric(self):
+        assert Stream(index=0, duration="120.5").duration_seconds() == 120.5
+
+    def test_duration_seconds_none(self):
+        assert Stream(index=0, duration=None).duration_seconds() is None
+
+    def test_duration_seconds_na(self):
+        assert Stream(index=0, duration="N/A").duration_seconds() is None
+
+    def test_duration_seconds_garbage(self):
+        assert Stream(index=0, duration="abc").duration_seconds() is None
+
+
+class TestStreamKindPredicates:
+    def test_is_video(self):
+        s = Stream(index=0, codec_type="video")
+        assert s.is_video is True
+        assert s.is_audio is False
+        assert s.is_subtitle is False
+        assert s.is_data is False
+        assert s.is_attachment is False
+
+    def test_is_audio(self):
+        s = Stream(index=1, codec_type="audio")
+        assert s.is_audio is True
+        assert s.is_video is False
+
+    def test_is_subtitle(self):
+        s = Stream(index=2, codec_type="subtitle")
+        assert s.is_subtitle is True
+        assert s.is_video is False
+
+    def test_is_data(self):
+        s = Stream(index=3, codec_type="data")
+        assert s.is_data is True
+        assert s.is_attachment is False
+
+    def test_is_attachment(self):
+        s = Stream(index=4, codec_type="attachment")
+        assert s.is_attachment is True
+        assert s.is_data is False
+
+    def test_none_codec_type_all_false(self):
+        s = Stream(index=0, codec_type=None)
+        assert not s.is_video
+        assert not s.is_audio
+        assert not s.is_subtitle
+        assert not s.is_data
+        assert not s.is_attachment
+        assert not s.is_text_subtitle
+        assert not s.is_image_subtitle
+
+    def test_unknown_codec_type_all_false(self):
+        s = Stream(index=0, codec_type="nut_metadata")
+        assert not s.is_video
+        assert not s.is_audio
+        assert not s.is_subtitle
+        assert not s.is_data
+        assert not s.is_attachment
+
+    def test_text_subtitle_classification(self):
+        for name in ("subrip", "ass", "ssa", "mov_text", "webvtt"):
+            s = Stream(index=0, codec_type="subtitle", codec_name=name)
+            assert s.is_text_subtitle is True, name
+            assert s.is_image_subtitle is False, name
+
+    def test_image_subtitle_classification(self):
+        for name in ("hdmv_pgs_subtitle", "dvd_subtitle", "dvb_subtitle"):
+            s = Stream(index=0, codec_type="subtitle", codec_name=name)
+            assert s.is_image_subtitle is True, name
+            assert s.is_text_subtitle is False, name
+
+    def test_unknown_subtitle_codec_neither(self):
+        s = Stream(index=0, codec_type="subtitle", codec_name="some_future_codec")
+        assert s.is_subtitle is True
+        assert s.is_text_subtitle is False
+        assert s.is_image_subtitle is False
+
+    def test_subtitle_predicates_require_subtitle_codec_type(self):
+        # codec_name matching a subtitle codec but wrong codec_type -> False
+        s = Stream(index=0, codec_type="audio", codec_name="subrip")
+        assert s.is_text_subtitle is False
+        assert s.is_image_subtitle is False
+
+    def test_codec_type_enum_values(self):
+        assert CodecType.VIDEO == "video"
+        assert CodecType.AUDIO == "audio"
+        assert CodecType.SUBTITLE == "subtitle"
+        assert CodecType.DATA == "data"
+        assert CodecType.ATTACHMENT == "attachment"
 
 
 class TestFormat:
@@ -122,6 +225,23 @@ class TestFormat:
         assert fmt.nb_streams is None
         assert fmt.duration is None
         assert fmt.tags is None
+
+    def test_duration_seconds_numeric(self):
+        assert Format(duration="120.500000").duration_seconds() == pytest.approx(120.5)
+
+    def test_duration_seconds_none(self):
+        assert Format(duration=None).duration_seconds() is None
+
+    def test_duration_seconds_na(self):
+        assert Format(duration="N/A").duration_seconds() is None
+
+    def test_duration_seconds_garbage(self):
+        assert Format(duration="not-a-number").duration_seconds() is None
+
+    def test_duration_seconds_preserves_raw_string(self):
+        fmt = Format(duration="120.500000")
+        assert fmt.duration_seconds() == pytest.approx(120.5)
+        assert fmt.duration == "120.500000"
 
 
 SAMPLE_FFPROBE_JSON = msgspec.json.encode(
@@ -165,6 +285,18 @@ class TestProbeResult:
         assert result.format.filename == "video.mkv"
         assert result.format.duration == "120.500000"
 
+    def test_duration_seconds_delegates_to_format(self):
+        result = msgspec.json.decode(SAMPLE_FFPROBE_JSON, type=ProbeResult)
+        assert result.duration_seconds() == pytest.approx(120.5)
+
+    def test_duration_seconds_none_when_no_format(self):
+        result = ProbeResult(streams=[], format=None)
+        assert result.duration_seconds() is None
+
+    def test_duration_seconds_na_format(self):
+        result = ProbeResult(streams=[], format=Format(duration="N/A"))
+        assert result.duration_seconds() is None
+
 
 class TestProbeFunction:
     @patch("ffmpeg_wrap._probe.subprocess.run")
@@ -179,10 +311,58 @@ class TestProbeFunction:
         assert result.format.duration == "120.500000"
 
     @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_probe_assigns_per_type_ordinals(self, mock_run):
+        sample = msgspec.json.encode(
+            {
+                "streams": [
+                    {"index": 0, "codec_type": "video"},
+                    {"index": 1, "codec_type": "audio"},
+                    {"index": 2, "codec_type": "audio"},
+                    {"index": 3, "codec_type": "subtitle"},
+                    {"index": 4, "codec_type": "subtitle"},
+                ]
+            }
+        )
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=sample, stderr=b"")
+        result = probe("video.mkv")
+        ordinals = [(s.codec_type, s.type_index) for s in result.streams]
+        assert ordinals == [
+            ("video", 0),
+            ("audio", 0),
+            ("audio", 1),
+            ("subtitle", 0),
+            ("subtitle", 1),
+        ]
+        assert result.streams[4].map_specifier() == "0:s:1"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_probe_decodes_exotic_codec_type_without_error(self, mock_run):
+        """An unknown codec_type must decode fine (codec_type stays str, not enum)."""
+        sample = msgspec.json.encode({"streams": [{"index": 0, "codec_type": "future_kind", "codec_name": "xyz"}]})
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=sample, stderr=b"")
+        result = probe("video.mkv")
+        stream = result.streams[0]
+        assert stream.codec_type == "future_kind"
+        assert stream.is_video is False
+        assert stream.is_audio is False
+        assert stream.is_subtitle is False
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
     def test_probe_raises_on_subprocess_failure(self, mock_run):
         mock_run.side_effect = subprocess.CalledProcessError(returncode=1, cmd=["ffprobe"], stderr=b"No such file")
         with pytest.raises(FFmpegError, match="ffprobe error"):
             probe("missing.mkv")
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_probe_failure_populates_structured_error(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(returncode=1, cmd=["ffprobe"], stderr=b"No such file")
+        with pytest.raises(FFmpegError) as exc_info:
+            probe("missing.mkv")
+        err = exc_info.value
+        assert err.returncode == 1
+        assert err.stderr == "No such file"
+        assert err.cmd is not None
+        assert err.cmd[0] == "ffprobe"
 
     @patch("ffmpeg_wrap._probe.subprocess.run")
     def test_probe_raises_on_malformed_json(self, mock_run):
@@ -572,18 +752,25 @@ class TestValidate:
     @patch("ffmpeg_wrap._probe.subprocess.run")
     def test_validate_raises_on_permission_error(self, mock_run):
         mock_run.side_effect = PermissionError("[Errno 13] Permission denied: '/usr/bin/ffprobe'")
-        with pytest.raises(FFmpegError, match="ffprobe could not be executed"):
+        with pytest.raises(FFmpegError, match="ffprobe could not be executed") as exc_info:
             validate("video.mkv")
+        assert exc_info.value.cmd is not None
+        assert exc_info.value.cmd[-1].endswith("video.mkv")
 
     def test_validate_raises_on_invalid_loglevel(self):
         with pytest.raises(ValueError, match="invalid loglevel"):
             validate("video.mkv", loglevel="warningg")
 
-    def test_validate_accepts_all_valid_loglevels(self):
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_accepts_all_valid_loglevels(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
         valid = {"quiet", "panic", "fatal", "error", "warning", "info", "verbose", "debug", "trace"}
         for level in valid:
-            with contextlib.suppress(FFmpegError, OSError):
-                validate("video.mkv", loglevel=level)
+            # No ValueError (the validation guard accepts it) and the level
+            # reaches the ffprobe command after -v.
+            validate("video.mkv", loglevel=level)
+            cmd = mock_run.call_args[0][0]
+            assert cmd[cmd.index("-v") + 1] == level
 
     @patch("ffmpeg_wrap._probe.subprocess.run")
     def test_validate_extra_args_coerced_to_str(self, mock_run):

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -13,6 +13,10 @@ def test_all_names_accessible():
     assert hasattr(ffmpeg, "FFmpeg")
     assert hasattr(ffmpeg, "input")
     assert hasattr(ffmpeg, "validate")
+    assert hasattr(ffmpeg, "CodecType")
+    assert hasattr(ffmpeg, "encoders")
+    assert hasattr(ffmpeg, "has_encoder")
+    assert hasattr(ffmpeg, "filter_arg_escape")
 
 
 def test_input_returns_ffmpeg_instance():
@@ -38,5 +42,18 @@ def test_validate_is_callable():
 
 def test_all_exports_match():
     """__all__ contains all expected public names."""
-    expected = {"FFmpegError", "Stream", "Format", "ProbeResult", "probe", "FFmpeg", "input", "validate"}
+    expected = {
+        "FFmpegError",
+        "Stream",
+        "Format",
+        "ProbeResult",
+        "probe",
+        "FFmpeg",
+        "input",
+        "validate",
+        "CodecType",
+        "encoders",
+        "has_encoder",
+        "filter_arg_escape",
+    }
     assert set(ffmpeg.__all__) == expected

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,171 @@
+"""Verify the README usage snippets compile against the current public API.
+
+Each test reconstructs a documented chain and asserts the exact ``compile()``
+argv (or escaped string) shown in the README, so the docs cannot drift away
+from the shipped behavior.
+"""
+
+import ffmpeg_wrap as ffmpeg
+
+
+def test_lavfi_synthetic_source_snippet():
+    """The lavfi-source entry-point snippet compiles as documented."""
+    cmd = (
+        ffmpeg.input("anullsrc=channel_layout=stereo:sample_rate=48000", f="lavfi", t=5)
+        .output("silence.wav")
+        .overwrite_output()
+        .compile()
+    )
+    assert cmd == [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-t",
+        "5",
+        "-i",
+        "anullsrc=channel_layout=stereo:sample_rate=48000",
+        "silence.wav",
+    ]
+
+
+def test_filter_complex_fanout_snippet():
+    """filter_complex graph fanned to two mapped outputs."""
+    cmd = (
+        ffmpeg.input("input.mkv")
+        .filter_complex("[0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb]")
+        .output("full.mp4")
+        .map("[full]")
+        .output("thumb.mp4")
+        .map("[thumb]")
+        .overwrite_output()
+        .compile()
+    )
+    assert cmd == [
+        "ffmpeg",
+        "-y",
+        "-filter_complex",
+        "[0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb]",
+        "-i",
+        "input.mkv",
+        "-map",
+        "[full]",
+        "full.mp4",
+        "-map",
+        "[thumb]",
+        "thumb.mp4",
+    ]
+
+
+def test_filter_complex_script_snippet():
+    """filter_complex_script reads the graph from a file."""
+    cmd = ffmpeg.input("input.mkv").filter_complex_script("graph.txt").output("output.mp4").compile()
+    assert cmd == [
+        "ffmpeg",
+        "-filter_complex_script",
+        "graph.txt",
+        "-i",
+        "input.mkv",
+        "output.mp4",
+    ]
+
+
+def test_remux_repeated_map_snippet():
+    """Stream-preserving remux emits one -map per stream type."""
+    cmd = (
+        ffmpeg.input("input.mkv")
+        .output("output.mkv", c="copy")
+        .map("0:v")
+        .map("0:a")
+        .map("0:s")
+        .overwrite_output()
+        .compile()
+    )
+    assert cmd == [
+        "ffmpeg",
+        "-y",
+        "-i",
+        "input.mkv",
+        "-c",
+        "copy",
+        "-map",
+        "0:v",
+        "-map",
+        "0:a",
+        "-map",
+        "0:s",
+        "output.mkv",
+    ]
+
+
+def test_map_list_form_matches_repeated_map():
+    """Passing map=[...] expands to the same argv as repeated .map()."""
+    cmd = ffmpeg.input("input.mkv").output("output.mkv", c="copy", map=["0:v", "0:a", "0:s"]).compile()
+    assert cmd == [
+        "ffmpeg",
+        "-i",
+        "input.mkv",
+        "-c",
+        "copy",
+        "-map",
+        "0:v",
+        "-map",
+        "0:a",
+        "-map",
+        "0:s",
+        "output.mkv",
+    ]
+
+
+def test_filter_arg_escape_subtitles_snippet():
+    """filter_arg_escape produces the documented escaped subtitles= value."""
+    path = r"C:\videos\clip.srt"
+    graph = f"subtitles={ffmpeg.filter_arg_escape(path)}"
+    assert graph == r"subtitles='C\:\\videos\\clip.srt'"
+
+
+def test_hwaccel_method_snippet():
+    """The .hwaccel() sugar lands -hwaccel before -i, with -c:v on the output."""
+    cmd = (
+        ffmpeg.input("input.mkv")
+        .hwaccel("cuda")
+        .output("output.mp4")
+        .codec("v", "h264_nvenc")
+        .overwrite_output()
+        .compile()
+    )
+    assert cmd == [
+        "ffmpeg",
+        "-y",
+        "-hwaccel",
+        "cuda",
+        "-i",
+        "input.mkv",
+        "-c:v",
+        "h264_nvenc",
+        "output.mp4",
+    ]
+
+
+def test_hwaccel_input_kwarg_equivalent():
+    """input(..., hwaccel="cuda") is equivalent to the .hwaccel() form."""
+    cmd = ffmpeg.input("input.mkv", hwaccel="cuda").output("output.mp4").codec("v", "h264_nvenc").compile()
+    assert cmd == [
+        "ffmpeg",
+        "-hwaccel",
+        "cuda",
+        "-i",
+        "input.mkv",
+        "-c:v",
+        "h264_nvenc",
+        "output.mp4",
+    ]
+
+
+def test_error_handling_attributes_documented():
+    """FFmpegError exposes returncode/stderr/cmd as the README recipe relies on."""
+    err = ffmpeg.FFmpegError("ffmpeg error: boom", stderr="boom", returncode=1, cmd=["ffmpeg"])
+    assert str(err) == "ffmpeg error: boom"
+    assert err.returncode == 1
+    assert err.stderr == "boom"
+    assert err.cmd == ["ffmpeg"]

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "ffmpeg-wrap"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgspec" },


### PR DESCRIPTION
Additive, backward-compatible improvements to the builder, probe models, and error type, plus real-media integration tests. `str(FFmpegError)` and the existing `compile()`/`run()` signatures are unchanged.

## Builder
- **Structured `FFmpegError`** — `stderr`, `returncode`, `cmd` attributes so callers classify failures without scraping `str(e)`.
- **Repeatable & typed `map()`** — `.map("0:v").map("1:a")`, `.map(stream)`, `.map_stream(kind, ordinal, input=0)`; list-valued option values (`map=["0:v","1:a"]`, `metadata=[...]`) expand to repeated flags.
- **Stream-specifier helpers** — `.codec(kind, name)`, `.bitrate`, `.quality`, `.audio_filter`, `.video_filter`.
- **`.flag(*names)`** for valueless switches (distinct from omit-on-`None`).
- **Graph-level filters** — `.filter_complex()` / `.filter_complex_script()` with a dedicated `compile()` slot (after global args, before inputs).
- **Runner sugar** — `.hide_banner()`, `.loglevel(level)`, and `run(text=True)` for decoded `str` output. Failure path always captures stderr (teed live) so `FFmpegError.stderr` is populated even without `capture_stderr`.

## Probe & helpers
- **Typed accessors** — `duration_seconds()` on `Format`/`ProbeResult`/`Stream`; `is_video`/`is_audio`/`is_subtitle`/`is_data`/`is_attachment` and `is_text_subtitle`/`is_image_subtitle` predicates; `CodecType` StrEnum; `Stream.map_specifier()`/`type_index`. `codec_type` stays `str | None` so exotic values still decode.
- **Encoder introspection** — `encoders()` / `has_encoder()` (cached per ffmpeg path) and `.hwaccel(name)` input sugar.
- **`filter_arg_escape(value)`** — escape paths/values for filtergraph arguments.

## Tests & CI
- **Real-media integration tests**: a Makefile downloads `file.mkv`/`file_2.mkv` (git-ignored) and `make` runs the full suite; `tests/conftest.py` adds fixtures + an `integration` marker; tests auto-skip when ffmpeg or the media are absent. 31 integration tests run ffmpeg/ffprobe and re-probe the output, covering the full public surface.
- CI installs ffmpeg per OS and runs `make`; adds a runtime-only `import ffmpeg_wrap` smoke job across Python 3.10–3.14.
- Version bumped to **0.3.0**.

258 tests pass (227 unit + 31 integration).