### PR TITLE
Async ffmpeg_wrap.aio API + docs site (v0.4.0)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Docs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: latest
+          python-version: '3.13'
+          enable-cache: true
+
+      - name: Install project
+        run: uv sync --extra async --group docs
+
+      - name: Build docs
+        run: uv run --extra async --group docs mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5.0.0
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -5,6 +5,6 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7.0.0
       # https://github.com/j178/prek-action
-      - uses: j178/prek-action@v2
+      - uses: j178/prek-action@v2.0.4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'release'
     steps:
     - name: Check out repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7.0.0
 
     - name: Get the tag name for the release
       id: vars
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install uv
       id: setup-uv
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         version: latest
         python-version: "3.14"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
 
       - name: Install ffmpeg (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: latest
           python-version: ${{ matrix.python-version }}
@@ -65,10 +65,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: latest
           python-version: ${{ matrix.python-version }}
@@ -76,3 +76,9 @@ jobs:
 
       - name: Import ffmpeg_wrap without dev dependencies
         run: uv run --no-dev python -c "import ffmpeg_wrap; print(ffmpeg_wrap.__version__)"
+
+      - name: Core import stays AnyIO-free (incl. wildcard import)
+        run: uv run --no-dev python -c "import ffmpeg_wrap; from ffmpeg_wrap import *; import sys; assert 'anyio' not in sys.modules, 'anyio must not be imported by the core package'; print('core import is anyio-free')"
+
+      - name: Import async API with the [async] extra
+        run: uv run --no-dev --extra async python -c "import ffmpeg_wrap.aio; from ffmpeg_wrap import aio; print('aio import ok:', aio.run.__name__)"

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ wheels/
 .*/
 !.github/
 
-docs/
+# MkDocs build output
+site/
 
 # Coverage artifacts
 .coverage

--- a/README.md
+++ b/README.md
@@ -25,358 +25,58 @@ With pip:
 pip install ffmpeg-wrap
 ```
 
-## Usage
+## Quick start
 
 ```python
 import ffmpeg_wrap as ffmpeg
-```
 
-### Probe a media file
-
-```python
+# Probe a file into typed structures
 result = ffmpeg.probe("video.mkv")
-
 for stream in result.streams:
     print(stream.codec_name, stream.codec_type)
 
-if result.format:
-    print(result.format.duration)
-    print(result.format.format_name)
-```
-
-### Build and run an FFmpeg command
-
-```python
+# Build and run a command with the fluent builder
 ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().run()
 ```
 
-### Multiple inputs and outputs
+### Async
 
-```python
-(
-    ffmpeg.input("input.mkv", ss=10, t=30)
-    .output("clip.mp4", vcodec="libx264", acodec="aac")
-    .overwrite_output()
-    .run()
-)
+The asynchronous mirror of the API ships as an optional extra. With uv:
+
+```
+uv add "ffmpeg-wrap[async]"
 ```
 
-### Global arguments
+With pip:
 
-```python
-(
-    ffmpeg.input("input.mkv")
-    .output("output.mp4", c="copy")
-    .global_args("-hide_banner", "-loglevel", "error")
-    .overwrite_output()
-    .run()
-)
+```
+pip install "ffmpeg-wrap[async]"
 ```
 
-### Capture output
-
 ```python
-stdout, stderr = (
-    ffmpeg.input("input.mkv")
-    .output("output.mp4", c="copy")
-    .overwrite_output()
-    .run(capture_stdout=True, capture_stderr=True)
-)
+import anyio
+
+from ffmpeg_wrap import aio, input
+
+
+async def main():
+    await input("input.mkv").output("output.mp4", c="copy").overwrite_output().arun()
+    result = await aio.probe("output.mp4")
+    print(result.format.format_name if result.format else None)
+
+
+anyio.run(main)
 ```
 
-### Validate a media file
-
-`validate()` checks whether a file is valid media without parsing full probe output.
-It returns a `(ok, stderr)` tuple instead of raising on bad media.
-
-```python
-ok, stderr = ffmpeg.validate("video.mkv")
-if not ok:
-    print(f"Invalid media: {stderr}")
-```
-
-The default `loglevel="warning"` surfaces ffprobe warnings (non-monotonic DTS,
-unsupported codecs, truncated frames) in addition to hard errors. Use a stricter
-level when only fatal problems matter:
-
-```python
-ok, stderr = ffmpeg.validate("video.mkv", loglevel="error")
-ok, stderr = ffmpeg.validate("video.mkv", loglevel="fatal")
-```
-
-Pass extra ffprobe flags via `extra_args`:
-
-```python
-ok, stderr = ffmpeg.validate("video.mkv", extra_args=("-hide_banner",))
-```
-
-Use `validate()` when you only need a pass/fail check. Use `probe()` when you need
-stream and format metadata. The only exception `validate()` raises is `FFmpegError`
-when the ffprobe executable could not be run (missing, not executable, etc.).
-
-```python
-try:
-    ok, stderr = ffmpeg.validate("video.mkv")
-except ffmpeg.FFmpegError:
-    print("ffprobe could not be executed")
-```
-
-### Error handling
-
-```python
-try:
-    ffmpeg.probe("nonexistent.mkv")
-except ffmpeg.FFmpegError as e:
-    print(f"Probe failed: {e}")
-
-try:
-    ffmpeg.input("missing.mkv").output("out.mp4").run()
-except ffmpeg.FFmpegError as e:
-    print(f"FFmpeg failed: {e}")
-```
-
-`FFmpegError` carries structured introspection so you can classify a failure
-without re-parsing the message string. `str(e)` is still the human-readable
-message; the `returncode`, `stderr`, and `cmd` attributes describe the
-underlying process failure (each is `None` when not applicable):
-
-```python
-try:
-    ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().run()
-except ffmpeg.FFmpegError as e:
-    # Branch on the exit code / inspect stderr instead of scraping str(e).
-    if e.returncode == 1 and e.stderr and "No space left" in e.stderr:
-        raise
-    print(f"ffmpeg exited {e.returncode}: {e.stderr}")
-```
-
-This is the building block for consumer-side retry policies (e.g. retrying only
-on transient exit codes): the wrapper stays unopinionated about which failures
-are retryable and exposes the raw `returncode`/`stderr` for the caller to decide.
-
-### Custom executable paths
-
-```python
-result = ffmpeg.probe("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
-
-ok, stderr = ffmpeg.validate("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
-
-ffmpeg.input("input.mkv", ffmpeg_path="/usr/local/bin/ffmpeg").output("output.mp4").run()
-```
-
-### Pipelines always start at `input()`
-
-Every chain begins with `ffmpeg.input(...)`, which returns the `FFmpeg` builder.
-There is no separate `output()`/`graph()` entry point: outputs, filters, and
-global flags are all methods on the chain rooted at an input.
-
-Synthetic sources (test patterns, silence, color) are inputs too — pass the
-`lavfi` virtual device as the input and the source description as its
-"filename":
-
-```python
-(
-    ffmpeg.input("anullsrc=channel_layout=stereo:sample_rate=48000", f="lavfi", t=5)
-    .output("silence.wav")
-    .overwrite_output()
-    .run()
-)
-# ffmpeg -f lavfi -t 5 -i anullsrc=channel_layout=stereo:sample_rate=48000 silence.wav
-```
-
-### Complex pipelines
-
-Use `filter_complex()` for a graph-level `-filter_complex` and `map()` to wire
-its labelled outputs to multiple output files. The filtergraph is emitted in a
-dedicated slot (after global args, before inputs), so its placement no longer
-depends on which output it is attached to:
-
-```python
-(
-    ffmpeg.input("input.mkv")
-    .filter_complex("[0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb]")
-    .output("full.mp4").map("[full]")
-    .output("thumb.mp4").map("[thumb]")
-    .overwrite_output()
-    .run()
-)
-# ffmpeg -filter_complex [0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb] \
-#   -i input.mkv -map [full] full.mp4 -map [thumb] thumb.mp4
-```
-
-For large graphs, read them from a file with `filter_complex_script()` (mutually
-exclusive with `filter_complex()` at runtime):
-
-```python
-(
-    ffmpeg.input("input.mkv")
-    .filter_complex_script("graph.txt")
-    .output("output.mp4")
-    .run()
-)
-# ffmpeg -filter_complex_script graph.txt -i input.mkv output.mp4
-```
-
-`map()` is repeatable and accepts raw specifiers, so a stream-preserving remux
-emits one `-map` per stream type:
-
-```python
-(
-    ffmpeg.input("input.mkv")
-    .output("output.mkv", c="copy")
-    .map("0:v").map("0:a").map("0:s")
-    .overwrite_output()
-    .run()
-)
-# ffmpeg -i input.mkv -c copy -map 0:v -map 0:a -map 0:s output.mkv
-```
-
-The same expansion works by passing a list directly: `output("out.mkv",
-map=["0:v", "0:a", "0:s"])`. `map(stream)` accepts a `Stream` from `probe()` and
-emits its per-type specifier (e.g. `0:s:0`); `map_stream("s", 0)` builds the
-specifier explicitly.
-
-When embedding a path in a filtergraph (e.g. `subtitles=`), escape it with
-`filter_arg_escape()` so colons and backslashes in the path do not break the
-graph:
-
-```python
-path = r"C:\videos\clip.srt"
-graph = f"subtitles={ffmpeg.filter_arg_escape(path)}"
-# subtitles='C\:\\videos\\clip.srt'
-```
-
-### Hardware acceleration
-
-Discover what the installed ffmpeg build actually supports at runtime instead of
-guessing. `encoders()` returns the full set of encoder names (cached per
-ffmpeg path); `has_encoder()` is a single-name membership check:
-
-```python
-if ffmpeg.has_encoder("h264_nvenc"):
-    video_codec = "h264_nvenc"
-else:
-    video_codec = "libx264"
-```
-
-Request a hardware decode/acceleration backend with the `hwaccel` input option,
-or the discoverable `hwaccel()` sugar — both emit `-hwaccel` before the input's
-`-i`:
-
-```python
-(
-    ffmpeg.input("input.mkv")
-    .hwaccel("cuda")
-    .output("output.mp4")
-    .codec("v", video_codec)
-    .overwrite_output()
-    .run()
-)
-# ffmpeg -hwaccel cuda -i input.mkv -c:v h264_nvenc output.mp4
-
-# Equivalent, set directly on the input:
-ffmpeg.input("input.mkv", hwaccel="cuda").output("output.mp4").codec("v", video_codec)
-```
-
-The wrapper stays unopinionated about encoder tuning: it reports what is
-available and lets you choose the codec and parameters.
-
-## API Reference
-
-### probe(filename, ffprobe_path="ffprobe")
-
-Run ffprobe on a file and return a typed `ProbeResult`.
-
-- `filename` -- Path to the media file (str or PathLike).
-- `ffprobe_path` -- Path to the ffprobe executable. Defaults to `"ffprobe"`.
-- Returns: `ProbeResult` with `streams` and `format` fields.
-- Raises: `FFmpegError` on subprocess failure or invalid output.
-
-### validate(filename, ffprobe_path="ffprobe", loglevel="warning", extra_args=())
-
-Run ffprobe in validation mode and check for errors/warnings.
-
-- `filename` -- Path to the media file (str or PathLike).
-- `ffprobe_path` -- Path to the ffprobe executable. Defaults to `"ffprobe"`.
-- `loglevel` -- Value passed to ffprobe's `-v` flag. Defaults to `"warning"` (surfaces DTS/codec warnings). Use `"error"` to ignore warnings or `"fatal"`/`"panic"` for only unrecoverable failures.
-- `extra_args` -- Additional raw arguments forwarded to ffprobe before the filename, e.g. `("-hide_banner",)`.
-- Returns: `tuple[bool, str]` -- `(ok, stderr_text)`. `ok` is `True` when ffprobe exits with code 0 and stderr is empty after stripping whitespace.
-- Raises: `FFmpegError` only when the ffprobe executable could not be run. Does not raise on invalid media.
-
-### input(filename, ffmpeg_path="ffmpeg", **kwargs)
-
-Create a new `FFmpeg` builder chain starting with an input file.
-
-- `filename` -- Input file path.
-- `ffmpeg_path` -- Path to the ffmpeg executable. Defaults to `"ffmpeg"`.
-- `**kwargs` -- Input options passed as FFmpeg flags (e.g., `ss=10`, `t=30`).
-- Returns: `FFmpeg` instance for method chaining.
-
-### FFmpeg
-
-Fluent builder for FFmpeg commands.
-
-- `input(filename, **kwargs)` -- Add an input file with options.
-- `output(filename, **kwargs)` -- Add an output file with options. List/tuple values expand to a repeated flag (e.g. `map=["0:v", "0:a"]`).
-- `overwrite_output()` -- Add the `-y` flag to overwrite existing output files.
-- `global_args(*args)` -- Add global arguments before inputs.
-- `map(*specs)` -- Append one `-map` per spec on the current output. Accepts raw specifiers (`"0:v"`) or a `Stream` (emits its per-type specifier). Repeatable.
-- `map_stream(kind, ordinal, input=0)` -- Append `-map {input}:{kind}:{ordinal}` (e.g. `map_stream("s", 0)` -> `-map 0:s:0`).
-- `codec(kind, name)` -- `-c:{kind} {name}` on the current output (e.g. `codec("v", "libx264")`).
-- `bitrate(kind, value)` -- `-b:{kind} {value}`.
-- `quality(kind, value)` -- `-q:{kind} {value}`.
-- `audio_filter(chain)` / `video_filter(chain)` -- `-filter:a` / `-filter:v` on the current output.
-- `flag(*names)` -- Append bare `-{name}` switches (e.g. `flag("vn", "sn")`).
-- `filter_complex(graph_str)` -- Graph-level `-filter_complex`, emitted in a dedicated slot after global args and before inputs.
-- `filter_complex_script(path)` -- Graph-level `-filter_complex_script` (mutually exclusive with `filter_complex()` at runtime).
-- `hwaccel(name)` -- Input-side `-hwaccel {name}` sugar, emitted before `-i`.
-- `hide_banner()` -- `-hide_banner` global flag.
-- `loglevel(level)` -- `-loglevel {level}` global flag.
-- `compile()` -- Build the command as a list of strings without executing it.
-- `run(capture_stdout=False, capture_stderr=False, text=False)` -- Execute the command. Returns `(stdout, stderr)`. With `text=True` the captured values are `str`; otherwise `bytes` (or `None` when the corresponding capture flag is `False`). Raises `FFmpegError` on failure.
-
-### ProbeResult
-
-Typed result from ffprobe.
-
-- `streams` -- List of `Stream` objects.
-- `format` -- Optional `Format` object.
-- `duration_seconds()` -- `float | None`. Delegates to `format.duration_seconds()`; `None` when there is no format.
-
-### Stream
-
-A single stream from ffprobe output. Fields include `index`, `codec_name`, `codec_type`, `type_index`, `width`, `height`, `channels`, `sample_rate`, `duration`, `bit_rate`, `tags`, `disposition`.
-
-- `map_specifier(input_index=0)` -- The per-type `-map` specifier for this stream (e.g. `0:s:0`), falling back to the absolute-index form for unknown `codec_type`.
-- `duration_seconds()` -- `float | None`. Parses `duration`, returning `None` for missing/`"N/A"`/non-numeric values.
-- `is_video` / `is_audio` / `is_subtitle` / `is_data` / `is_attachment` -- Properties comparing `codec_type` against `CodecType`. All `False` for unknown/`None`.
-- `is_text_subtitle` / `is_image_subtitle` -- Best-effort properties classifying a subtitle stream by `codec_name`.
-
-### Format
-
-The format section from ffprobe output. Fields include `filename`, `nb_streams`, `nb_programs`, `format_name`, `format_long_name`, `start_time`, `duration`, `size`, `bit_rate`, `probe_score`, `tags`.
-
-- `duration_seconds()` -- `float | None`. Parses `duration`, returning `None` for missing/`"N/A"`/non-numeric values (the raw `duration: str` is preserved).
-
-### CodecType
-
-`StrEnum` of the known ffprobe `codec_type` values (`VIDEO`, `AUDIO`, `SUBTITLE`, `DATA`, `ATTACHMENT`). Used by the `Stream` predicates. `Stream.codec_type` stays typed `str | None` so exotic values still decode without `ValidationError` — compare against these members rather than retyping the field.
-
-### encoders(ffmpeg_path="ffmpeg")
-
-Return the set of encoder names supported by the installed ffmpeg build.
-
-- Parses `ffmpeg -hide_banner -encoders`; the result is cached per `ffmpeg_path`.
-- Returns: `frozenset[str]`.
-
-### has_encoder(name, ffmpeg_path="ffmpeg")
-
-`bool`. Whether `name` is in `encoders(ffmpeg_path)`. Use this instead of hard-coding encoder availability.
-
-### filter_arg_escape(value)
-
-`str`. Escape a value for use inside a filtergraph argument (e.g. a `subtitles=` path), handling `\`, `:`, and `'`, and wrapping the result in single quotes.
-
-### FFmpegError
-
-Exception raised when FFmpeg or ffprobe operations fail. `str(e)` is the human-readable message; the keyword-only attributes `stderr` (`str | None`), `returncode` (`int | None`), and `cmd` (`list[str] | None`) describe the underlying process failure and are `None` when not applicable.
+## Documentation
+
+Full documentation, including guides and the complete API reference, is hosted at
+[gitbib.github.io/ffmpeg-wrap](https://gitbib.github.io/ffmpeg-wrap/):
+
+- **[Guide](https://gitbib.github.io/ffmpeg-wrap/guide/)** — a walkthrough of the
+  synchronous API: probing files, building and running commands, mapping streams,
+  complex filtergraphs, validation, encoder discovery, and error handling.
+- **[Async API](https://gitbib.github.io/ffmpeg-wrap/async/)** — the AnyIO-backed
+  asynchronous mirror, backend choice (asyncio or trio), and bounding concurrency.
+- **[API Reference](https://gitbib.github.io/ffmpeg-wrap/reference/sync/)** — the
+  auto-generated reference for every public function, builder method, and model.

--- a/docs/async.md
+++ b/docs/async.md
@@ -1,0 +1,138 @@
+# Async API
+
+An asynchronous mirror of the public API lives under `ffmpeg_wrap.aio`, powered
+by [AnyIO](https://anyio.readthedocs.io/). It lets you drive many
+ffmpeg/ffprobe jobs concurrently without blocking the event loop. The core
+package stays dependency-free — `import ffmpeg_wrap` never imports anyio — so
+the async path ships as an optional extra. With uv:
+
+```
+uv add "ffmpeg-wrap[async]"
+```
+
+With pip:
+
+```
+pip install "ffmpeg-wrap[async]"
+```
+
+See the auto-generated [Async API Reference](reference/async.md) for full
+signatures.
+
+## Running a command
+
+The fluent builder gains an `arun()` method that mirrors `run()`. Start the
+chain at `input()` exactly as in the sync API, then `await` the result:
+
+```python
+import anyio
+
+from ffmpeg_wrap import input
+
+
+async def main():
+    await (
+        input("input.mkv")
+        .output("output.mp4", c="copy")
+        .overwrite_output()
+        .arun()
+    )
+
+
+anyio.run(main)
+```
+
+## Mirrored module functions
+
+The `aio` submodule mirrors the module-level functions. `aio.probe()` returns
+the same typed `ProbeResult` as `probe()`; `aio.validate()` returns the same
+`(ok, stderr)` tuple; `aio.encoders()`/`aio.has_encoder()` share the same
+per-path cache as their sync twins:
+
+```python
+import anyio
+
+from ffmpeg_wrap import aio
+
+
+async def main():
+    result = await aio.probe("video.mkv")
+    for stream in result.streams:
+        print(stream.codec_name, stream.codec_type)
+
+    ok, stderr = await aio.validate("video.mkv")
+    if not ok:
+        print(f"Invalid media: {stderr}")
+
+    codec = "h264_nvenc" if await aio.has_encoder("h264_nvenc") else "libx264"
+    print(codec)
+
+
+anyio.run(main)
+```
+
+## Backend choice (asyncio or trio)
+
+Because the async path is built on AnyIO, the same library code runs on both the
+asyncio and trio backends — the consumer picks the backend. `anyio.run(main)`
+uses asyncio by default; pass `backend="trio"` to run on trio instead:
+
+```python
+import anyio
+
+from ffmpeg_wrap import aio
+
+
+async def main():
+    await aio.probe("video.mkv")
+
+
+anyio.run(main, backend="trio")
+```
+
+!!! note "Thread behaviour under highload"
+    On the asyncio backend, depending on platform and Python version, CPython
+    may reap child processes with **one `waitpid` thread per subprocess** (the
+    threaded child watcher) — so its reaping-thread count grows with the number
+    of concurrently running children; newer CPython (3.14+) can instead use a
+    **pidfd-based watcher with no thread**. On the trio backend there is **no
+    dedicated child-reaping thread** at all. AnyIO's trio backend does, however,
+    use a small **bounded, reusable worker-thread pool** for the blocking
+    pipe-FD reads behind `run_process`/`open_process`. That pool scales with the
+    number of *concurrently running* ffmpeg processes (threads are reused across
+    jobs), not with the total number of jobs you queue — so bounding concurrency
+    with a `CapacityLimiter` keeps the thread count flat. Trio avoids a
+    per-process reaping thread, but it is not literally zero-thread.
+
+## Bounding concurrency
+
+The library does not build a job queue — bound concurrency yourself with an
+`anyio.CapacityLimiter` so only N ffmpeg processes run at once, while you queue
+as many jobs as you like:
+
+```python
+import anyio
+
+from ffmpeg_wrap import input
+
+
+async def transcode(name, limiter):
+    async with limiter:
+        await (
+            input(f"{name}.mkv")
+            .output(f"{name}.mp4", c="copy")
+            .overwrite_output()
+            .arun()
+        )
+
+
+async def main():
+    limiter = anyio.CapacityLimiter(4)  # at most 4 concurrent ffmpeg processes
+    names = [f"clip{i}" for i in range(100)]
+    async with anyio.create_task_group() as tg:
+        for name in names:
+            tg.start_soon(transcode, name, limiter)
+
+
+anyio.run(main)
+```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,173 @@
+# Guide
+
+This page walks through the synchronous API. For exhaustive signatures and field
+documentation, see the auto-generated [API Reference](reference/sync.md).
+
+```python
+import ffmpeg_wrap as ffmpeg
+```
+
+## Probe a media file
+
+```python
+result = ffmpeg.probe("video.mkv")
+
+for stream in result.streams:
+    print(stream.codec_name, stream.codec_type)
+
+if result.format:
+    print(result.format.duration)
+    print(result.format.format_name)
+```
+
+`probe()` raises `FFmpegError` on subprocess failure or invalid output.
+
+## Build and run a command
+
+Every chain starts at `ffmpeg.input(...)`, which returns the `FFmpeg` builder.
+Outputs, filters, and global flags are all methods on that chain.
+
+```python
+ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().run()
+```
+
+Input/output options are passed as keyword arguments:
+
+```python
+(
+    ffmpeg.input("input.mkv", ss=10, t=30)
+    .output("clip.mp4", vcodec="libx264", acodec="aac")
+    .overwrite_output()
+    .run()
+)
+```
+
+Use `global_args()` for flags before the inputs, and `run(capture_stdout=...,
+capture_stderr=...)` to capture process output.
+
+Synthetic sources (test patterns, silence, color) are inputs too. Pass the
+`lavfi` virtual device as the input and the source description as its
+"filename":
+
+```python
+(
+    ffmpeg.input("anullsrc=channel_layout=stereo:sample_rate=48000", f="lavfi", t=5)
+    .output("silence.wav")
+    .overwrite_output()
+    .run()
+)
+# ffmpeg -f lavfi -t 5 -i anullsrc=channel_layout=stereo:sample_rate=48000 silence.wav
+```
+
+By default the builder runs the `ffmpeg`/`ffprobe` executables found on `PATH`.
+If they live elsewhere, point the builder and the probe helpers at the
+executables explicitly with `ffmpeg_path` and `ffprobe_path`:
+
+```python
+result = ffmpeg.probe("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
+
+ok, stderr = ffmpeg.validate("video.mkv", ffprobe_path="/usr/local/bin/ffprobe")
+
+ffmpeg.input("input.mkv", ffmpeg_path="/usr/local/bin/ffmpeg").output("output.mp4").run()
+```
+
+## Mapping and complex graphs
+
+`map()` is repeatable and accepts raw specifiers or a `Stream` from `probe()`.
+Use `filter_complex()` for a graph-level `-filter_complex` and wire labelled
+outputs to multiple files:
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .filter_complex("[0:v]split=2[full][thumb];[thumb]scale=320:-2[thumb]")
+    .output("full.mp4").map("[full]")
+    .output("thumb.mp4").map("[thumb]")
+    .overwrite_output()
+    .run()
+)
+```
+
+For large graphs, read them from a file with `filter_complex_script()`. It is
+mutually exclusive with `filter_complex()` at runtime, so use one or the other:
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .filter_complex_script("graph.txt")
+    .output("output.mp4")
+    .run()
+)
+# ffmpeg -filter_complex_script graph.txt -i input.mkv output.mp4
+```
+
+When embedding a path inside a filtergraph (e.g. `subtitles=`), escape it with
+`filter_arg_escape()`:
+
+```python
+path = r"C:\videos\clip.srt"
+graph = f"subtitles={ffmpeg.filter_arg_escape(path)}"
+# subtitles='C\:\\videos\\clip.srt'
+```
+
+## Validate a media file
+
+`validate()` checks whether a file is valid media and returns a `(ok, stderr)`
+tuple instead of raising on bad media. It only raises `FFmpegError` when the
+ffprobe executable itself could not be run.
+
+```python
+ok, stderr = ffmpeg.validate("video.mkv")
+if not ok:
+    print(f"Invalid media: {stderr}")
+```
+
+The default `loglevel="warning"` surfaces ffprobe warnings (non-monotonic DTS,
+unsupported codecs, truncated frames). Use `"error"` or `"fatal"` when only
+hard failures matter, and pass extra ffprobe flags via `extra_args`.
+
+## Encoder discovery
+
+Discover what the installed ffmpeg build supports at runtime instead of
+hard-coding it. `encoders()` returns the full set (cached per ffmpeg path);
+`has_encoder()` is a single-name membership check:
+
+```python
+if ffmpeg.has_encoder("h264_nvenc"):
+    video_codec = "h264_nvenc"
+else:
+    video_codec = "libx264"
+```
+
+Request a hardware acceleration backend with `hwaccel()` (emits `-hwaccel`
+before the input's `-i`):
+
+```python
+(
+    ffmpeg.input("input.mkv")
+    .hwaccel("cuda")
+    .output("output.mp4")
+    .codec("v", video_codec)
+    .overwrite_output()
+    .run()
+)
+```
+
+## Error handling
+
+`FFmpegError` carries structured introspection so you can classify a failure
+without re-parsing the message. `str(e)` is the human-readable message; the
+`returncode`, `stderr`, and `cmd` attributes describe the underlying process
+failure (each is `None` when not applicable):
+
+```python
+try:
+    ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().run()
+except ffmpeg.FFmpegError as e:
+    if e.returncode == 1 and e.stderr and "No space left" in e.stderr:
+        raise
+    print(f"ffmpeg exited {e.returncode}: {e.stderr}")
+```
+
+This is the building block for consumer-side retry policies: the wrapper stays
+unopinionated about which failures are retryable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,74 @@
+# ffmpeg-wrap
+
+A typed Python wrapper for FFmpeg and ffprobe. Build FFmpeg commands with a
+fluent API and parse ffprobe output into typed [msgspec](https://msgspec.dev/)
+models. The core package is dependency-light (just `msgspec`) and ships both a
+synchronous API and an optional [AnyIO](https://anyio.readthedocs.io/)-backed
+async mirror.
+
+## Requirements
+
+- Python 3.10+
+- FFmpeg and ffprobe installed and available on `PATH`
+
+## Installation
+
+With uv:
+
+```
+uv add ffmpeg-wrap
+```
+
+With pip:
+
+```
+pip install ffmpeg-wrap
+```
+
+The async API lives behind an optional extra:
+
+```
+uv add "ffmpeg-wrap[async]"
+```
+
+Or with pip:
+
+```
+pip install "ffmpeg-wrap[async]"
+```
+
+## Sync example
+
+```python
+import ffmpeg_wrap as ffmpeg
+
+result = ffmpeg.probe("video.mkv")
+for stream in result.streams:
+    print(stream.codec_name, stream.codec_type)
+
+ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().run()
+```
+
+## Async example
+
+```python
+import anyio
+
+from ffmpeg_wrap import aio, input
+
+
+async def main():
+    await input("input.mkv").output("output.mp4", c="copy").overwrite_output().arun()
+    result = await aio.probe("output.mp4")
+    print(result.format.format_name if result.format else None)
+
+
+anyio.run(main)
+```
+
+## Where to next
+
+- [Guide](guide.md) — sync usage: the builder chain, probing, validation, encoder discovery.
+- [Async API](async.md) — the AnyIO-backed mirror, backend choice, and bounding concurrency.
+- [API Reference — Sync](reference/sync.md) — auto-generated reference for the public sync surface.
+- [API Reference — Async](reference/async.md) — auto-generated reference for `ffmpeg_wrap.aio`.

--- a/docs/reference/async.md
+++ b/docs/reference/async.md
@@ -1,0 +1,7 @@
+# API Reference — Async
+
+The asynchronous mirror under `ffmpeg_wrap.aio`, generated from its Google-style
+docstrings. Requires the optional `[async]` extra (`uv add "ffmpeg-wrap[async]"`,
+or `pip install "ffmpeg-wrap[async]"`).
+
+::: ffmpeg_wrap.aio

--- a/docs/reference/sync.md
+++ b/docs/reference/sync.md
@@ -1,0 +1,38 @@
+# API Reference — Sync
+
+The following reference is generated directly from the package's Google-style
+docstrings via [mkdocstrings](https://mkdocstrings.github.io/).
+
+## Builder
+
+::: ffmpeg_wrap.input
+
+::: ffmpeg_wrap.FFmpeg
+
+## Probing
+
+::: ffmpeg_wrap.probe
+
+::: ffmpeg_wrap.validate
+
+::: ffmpeg_wrap.ProbeResult
+
+::: ffmpeg_wrap.Stream
+
+::: ffmpeg_wrap.Format
+
+::: ffmpeg_wrap.CodecType
+
+## Encoder discovery
+
+::: ffmpeg_wrap.encoders
+
+::: ffmpeg_wrap.has_encoder
+
+## Filters
+
+::: ffmpeg_wrap.filter_arg_escape
+
+## Errors
+
+::: ffmpeg_wrap.FFmpegError

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: ffmpeg-wrap
+site_description: Typed fluent FFmpeg/ffprobe wrapper with msgspec models
+site_url: https://gitbib.github.io/ffmpeg-wrap/
+repo_url: https://github.com/GitBib/ffmpeg-wrap
+repo_name: GitBib/ffmpeg-wrap
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_signature_annotations: true
+            separate_signature: true
+            merge_init_into_class: true
+            show_root_heading: true
+            members_order: source
+
+exclude_docs: |
+  plans/
+
+nav:
+  - Home: index.md
+  - Guide: guide.md
+  - Async API: async.md
+  - API Reference:
+      - Sync: reference/sync.md
+      - Async: reference/async.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-wrap"
-version = "0.3.0"
+version = "0.4.0"
 description = "Typed fluent FFmpeg/ffprobe wrapper with msgspec models"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -9,6 +9,8 @@ authors = [{ name = "GitBib" }]
 keywords = ["ffmpeg", "ffprobe", "video", "audio", "media", "wrapper", "msgspec"]
 classifiers = [
     "Development Status :: 4 - Beta",
+    "Framework :: AsyncIO",
+    "Framework :: Trio",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.10",
@@ -24,14 +26,26 @@ dependencies = [
     "msgspec>=0.21.0",
 ]
 
+[project.optional-dependencies]
+async = ["anyio>=4.0"]
+
 [project.urls]
 Homepage = "https://github.com/GitBib/ffmpeg-wrap"
+Documentation = "https://gitbib.github.io/ffmpeg-wrap/"
 Repository = "https://github.com/GitBib/ffmpeg-wrap"
 Issues = "https://github.com/GitBib/ffmpeg-wrap/issues"
 
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "pytest-timeout>=2.3",
+    "anyio>=4.0",
+    "trio>=0.25",
+]
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.27",
 ]
 
 [build-system]
@@ -43,6 +57,11 @@ packages = ["src/ffmpeg_wrap"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+anyio_mode = "auto"
+# Backstop against a hung subprocess/async test (the in-test ``fail_after`` guards
+# fire first at lower values); the thread method works cross-platform, incl. Windows.
+timeout = 300
+timeout_method = "thread"
 
 [tool.ruff]
 line-length = 120

--- a/src/ffmpeg_wrap/__init__.py
+++ b/src/ffmpeg_wrap/__init__.py
@@ -1,13 +1,25 @@
 from importlib.metadata import version
+from typing import TYPE_CHECKING
 
-from ._builder import FFmpeg, input
-from ._encoders import encoders, has_encoder
-from ._errors import FFmpegError
-from ._filters import filter_arg_escape
-from ._probe import CodecType, Format, ProbeResult, Stream, probe, validate
+from ffmpeg_wrap._builder import FFmpeg, input
+from ffmpeg_wrap._encoders import encoders, has_encoder
+from ffmpeg_wrap._errors import FFmpegError
+from ffmpeg_wrap._filters import filter_arg_escape
+from ffmpeg_wrap._probe import CodecType, Format, ProbeResult, Stream, probe, validate
+
+if TYPE_CHECKING:
+    from ffmpeg_wrap import aio as aio
 
 __version__ = version("ffmpeg-wrap")
 
+# ``aio`` is intentionally NOT eagerly imported above: it pulls in the optional
+# ``anyio`` dependency, and the core package must stay dependency-free. It is
+# resolved lazily via the PEP 562 module ``__getattr__`` below, so ``from
+# ffmpeg_wrap import aio`` (and ``import ffmpeg_wrap.aio``) works without making
+# ``import ffmpeg_wrap`` import anyio. ``aio`` is deliberately ABSENT from
+# ``__all__``: a name in ``__all__`` makes ``from ffmpeg_wrap import *`` bind it,
+# which would eagerly trigger ``__getattr__`` -> import anyio and break wildcard
+# import when the optional ``[async]`` extra is not installed.
 __all__ = [
     "CodecType",
     "FFmpeg",
@@ -22,3 +34,19 @@ __all__ = [
     "probe",
     "validate",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily resolve the optional ``aio`` submodule (PEP 562).
+
+    Accessing ``ffmpeg_wrap.aio`` imports the anyio-backed submodule on first
+    use and caches it in module globals, so subsequent attribute accesses skip
+    this hook entirely. Importing ``ffmpeg_wrap`` itself never imports anyio.
+    """
+    if name == "aio":
+        import importlib
+
+        mod = importlib.import_module("ffmpeg_wrap.aio")
+        globals()["aio"] = mod
+        return mod
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ffmpeg_wrap/_builder.py
+++ b/src/ffmpeg_wrap/_builder.py
@@ -1,24 +1,65 @@
 from __future__ import annotations
 
-import collections
 import locale
 import logging
 import os
 import subprocess
-import sys
+import sys  # noqa: F401  # re-exported so tests can patch ``_builder.sys.stderr`` (the shared TeePump reads ``sys.stderr``)
 import threading
 from typing import Any, Literal, overload
 
-from ._errors import FFmpegError
-from ._probe import Stream
+from ffmpeg_wrap import _textio
+from ffmpeg_wrap._errors import FFmpegError, _build_ffmpeg_error
+from ffmpeg_wrap._probe import Stream
+from ffmpeg_wrap._textio import TeePump, decode_text
 
 logger = logging.getLogger("ffmpeg_wrap")
 
 
 class FFmpeg:
-    """A fluent interface wrapper for ffmpeg."""
+    """A fluent interface wrapper for ffmpeg.
+
+    Build an ffmpeg command incrementally via method chaining and execute it
+    with :meth:`run` (sync) or :meth:`arun` (async). Every builder method
+    returns ``self`` so calls can be chained in a single expression.
+
+    Args:
+        ffmpeg_path: Path to the ffmpeg executable. Defaults to ``"ffmpeg"``,
+            which relies on the executable being present on ``PATH``. Pass an
+            absolute path to pin a specific build.
+
+    Example:
+        ```python
+        from ffmpeg_wrap import input
+
+        out, _ = (
+            input("in.mkv")
+            .output("out.mp4")
+            .codec("v", "libx264")
+            .codec("a", "aac")
+            .overwrite_output()
+            .run(capture_stderr=True, text=True)
+        )
+        ```
+    """
 
     def __init__(self, ffmpeg_path: str = "ffmpeg") -> None:
+        """Initialise the FFmpeg command builder.
+
+        Args:
+            ffmpeg_path: Path to the ffmpeg executable. Defaults to
+                ``"ffmpeg"`` (resolved from ``PATH``). Pass an absolute path
+                to target a specific ffmpeg build, e.g.
+                ``"/usr/local/bin/ffmpeg"``.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import FFmpeg
+
+            ff = FFmpeg(ffmpeg_path="/usr/local/bin/ffmpeg")
+            ff.input("in.mkv").output("out.mp4").run()
+            ```
+        """
         self._inputs: list[dict[str, Any]] = []
         self._outputs: list[dict[str, Any]] = []
         self._global_args: list[str] = []
@@ -31,6 +72,15 @@ class FFmpeg:
 
         Returns:
             The command as a list of strings.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            cmd = input("in.mkv").output("out.mp4").codec("v", "copy").compile()
+            # ['ffmpeg', '-i', '/abs/path/in.mkv', '-c:v', 'copy', 'out.mp4']
+            print(cmd)
+            ```
         """
         cmd = [self._ffmpeg_path]
 
@@ -62,6 +112,14 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import FFmpeg
+
+            ff = FFmpeg().input("clip.mkv", ss=30, t=60)
+            # Emits: -ss 30 -t 60 -i clip.mkv
+            ```
         """
         self._inputs.append({"filename": os.fsdecode(filename), "kwargs": kwargs})
         return self
@@ -75,6 +133,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4", c="copy", ac=2)
+            ```
         """
         self._outputs.append({"filename": os.fsdecode(filename), "kwargs": kwargs})
         return self
@@ -111,6 +176,15 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input, probe
+
+            result = probe("in.mkv")
+            video = next(s for s in result.streams if s.is_video)
+            input("in.mkv").output("out.mkv").map("0:a", video)
+            ```
         """
         tokens = [spec.map_specifier() if isinstance(spec, Stream) else str(spec) for spec in specs]
         self._append_output_list("map", tokens)
@@ -126,6 +200,14 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            # Map first video and second audio stream from input 0
+            input("in.mkv").output("out.mkv").map_stream("v", 0).map_stream("a", 1)
+            ```
         """
         self._append_output_list("map", [f"{input}:{kind}:{ordinal}"])
         return self
@@ -152,6 +234,14 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import FFmpeg
+
+            ff = FFmpeg().input("in.mkv").hwaccel("cuda").output("out.mp4")
+            # Emits: -hwaccel cuda -i in.mkv out.mp4
+            ```
         """
         self._set_input_option("hwaccel", name)
         return self
@@ -178,6 +268,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").codec("v", "libx264").codec("a", "aac")
+            ```
         """
         self._set_output_option(f"c:{kind}", name)
         return self
@@ -194,6 +291,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").codec("v", "libx264").bitrate("v", "2M")
+            ```
         """
         self._set_output_option(f"b:{kind}", value)
         return self
@@ -209,6 +313,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp3").codec("a", "libmp3lame").quality("a", 2)
+            ```
         """
         self._set_output_option(f"q:{kind}", value)
         return self
@@ -223,6 +334,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mkv").audio_filter("loudnorm")
+            ```
         """
         self._set_output_option("filter:a", chain)
         return self
@@ -237,6 +355,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").video_filter("scale=1280:-2")
+            ```
         """
         self._set_output_option("filter:v", chain)
         return self
@@ -253,28 +378,50 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            # Extract audio only: suppress video and subtitle streams
+            input("in.mkv").output("out.aac").flag("vn", "sn")
+            ```
         """
         for name in names:
             self._set_output_option(name, True)
         return self
 
     def overwrite_output(self) -> FFmpeg:
-        """Add the -y flag to overwrite output files.
+        """Add the ``-y`` flag to overwrite output files without prompting.
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").overwrite_output().run()
+            ```
         """
         self._overwrite = True
         return self
 
     def global_args(self, *args: str) -> FFmpeg:
-        """Add global arguments.
+        """Add raw global arguments emitted before input options.
 
         Args:
-            *args: Global arguments.
+            *args: Global arguments (e.g. ``"-nostdin"``, ``"-benchmark"``).
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").global_args("-nostdin", "-benchmark")
+            ```
         """
         self._global_args.extend(args)
         return self
@@ -286,6 +433,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").hide_banner().run()
+            ```
         """
         self._global_args.append("-hide_banner")
         return self
@@ -300,6 +454,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").output("out.mp4").loglevel("error").run()
+            ```
         """
         self._global_args.extend(["-loglevel", level])
         return self
@@ -318,6 +479,17 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            (
+                input("in.mkv")
+                .filter_complex("[0:v]split=2[a][b];[a]scale=640:-2[out]")
+                .output("out.mp4", map="[out]")
+            )
+            ```
         """
         self._filter_graph_args = ["-filter_complex", graph_str]
         return self
@@ -334,6 +506,13 @@ class FFmpeg:
 
         Returns:
             Self for chaining.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import input
+
+            input("in.mkv").filter_complex_script("graph.txt").output("out.mp4").run()
+            ```
         """
         self._filter_graph_args = ["-filter_complex_script", os.fsdecode(path)]
         return self
@@ -379,6 +558,21 @@ class FFmpeg:
 
         Raises:
             FFmpegError: If ffmpeg fails.
+
+        Example:
+            ```python
+            import ffmpeg_wrap as ffmpeg
+
+            try:
+                _, stderr = (
+                    ffmpeg.input("in.mkv")
+                    .output("out.mp4")
+                    .overwrite_output()
+                    .run(capture_stderr=True, text=True)
+                )
+            except ffmpeg.FFmpegError as e:
+                print(e.returncode, e.stderr)
+            ```
         """
         cmd = self.compile()
 
@@ -413,7 +607,7 @@ class FFmpeg:
                 stderr_text = e.stderr.decode("utf-8", errors="replace")
             err_msg = stderr_text or str(e)
             logger.error(f"FFmpeg command failed: {err_msg}")
-            raise FFmpegError(
+            raise _build_ffmpeg_error(
                 f"ffmpeg error: {err_msg}",
                 stderr=stderr_text,
                 returncode=e.returncode,
@@ -421,26 +615,79 @@ class FFmpeg:
             ) from e
         except OSError as e:
             logger.error(f"ffmpeg could not be executed: {e}")
-            raise FFmpegError(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+            raise _build_ffmpeg_error(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
 
-    # Maximum stderr tail retained for ``FFmpegError`` (ffmpeg's diagnostics
-    # land at the end of the stream, so a bounded tail keeps memory flat on
-    # long jobs while still capturing the actionable error text).
-    _STDERR_TAIL_BYTES = 256 * 1024
+    @overload
+    async def arun(
+        self,
+        capture_stdout: bool = ...,
+        capture_stderr: bool = ...,
+        *,
+        text: Literal[False] = ...,
+    ) -> tuple[bytes | None, bytes | None]: ...
 
-    @staticmethod
-    def _decode_text(data: bytes, encoding: str) -> str:
-        """Decode tee-path bytes the way ``subprocess.run(text=True)`` returns text.
+    @overload
+    async def arun(
+        self,
+        capture_stdout: bool = ...,
+        capture_stderr: bool = ...,
+        *,
+        text: Literal[True],
+    ) -> tuple[str | None, str | None]: ...
 
-        Mirrors subprocess's universal-newline translation (``\\r\\n`` and
-        ``\\r`` collapse to ``\\n``) so the returned stdout and
-        ``FFmpegError.stderr`` have the same shape regardless of which ``run()``
-        path produced them. Decoding stays lenient (``errors="replace"``)
-        rather than subprocess's strict default: a stray byte must never turn a
-        finished run — or the error report for a failed one — into a
-        ``UnicodeDecodeError``.
+    async def arun(
+        self,
+        capture_stdout: bool = False,
+        capture_stderr: bool = False,
+        *,
+        text: bool = False,
+    ) -> tuple[bytes | None, bytes | None] | tuple[str | None, str | None]:
+        """Build and execute the FFmpeg command asynchronously.
+
+        Async mirror of :meth:`run`, powered by AnyIO via the optional
+        ``[async]`` extra. The return contract is identical to :meth:`run`.
+        Importing this module never imports anyio — the dependency is pulled in
+        lazily here, so ``ffmpeg_wrap.aio`` (and thus anyio) is only loaded when
+        ``arun`` is actually awaited.
+
+        Args:
+            capture_stdout: Whether to capture stdout.
+            capture_stderr: Whether to capture stderr.
+            text: When True, decode stdout/stderr (and ``FFmpegError.stderr``)
+                leniently as text using the platform default encoding.
+
+        Returns:
+            Tuple of (stdout, stderr); see :meth:`run`.
+
+        Raises:
+            FFmpegError: If ffmpeg fails or cannot be executed.
+            ImportError: If the optional ``[async]`` extra is not installed.
+
+        Example:
+            ```python
+            import anyio
+            from ffmpeg_wrap import input
+
+            async def main():
+                _, stderr = await (
+                    input("in.mkv")
+                    .output("out.mp4")
+                    .overwrite_output()
+                    .arun(capture_stderr=True, text=True)
+                )
+
+            anyio.run(main)
+            ```
         """
-        return data.decode(encoding, errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+        from ffmpeg_wrap import aio
+
+        return await aio.run(self, capture_stdout, capture_stderr, text=text)
+
+    # Thin re-exports of the ``_textio`` versions so existing call sites and
+    # any tests referencing ``FFmpeg._decode_text`` / ``FFmpeg._STDERR_TAIL_BYTES``
+    # keep working. The single source of truth lives in ``_textio``.
+    _STDERR_TAIL_BYTES = _textio.STDERR_TAIL_BYTES
+    _decode_text = staticmethod(decode_text)
 
     @staticmethod
     def _run_tee(cmd: list[str], stdout_dest: int | None, text: bool) -> bytes | str | None:
@@ -451,45 +698,25 @@ class FFmpeg:
         carriage-return-terminated updates (``frame=...\\r``) rather than
         newline-terminated lines, so a line-oriented read would withhold all of
         it until EOF; chunked reads preserve the live progress of a bare
-        ``run()``. Only a bounded tail of stderr is retained, and it is decoded
-        and joined solely on the failure path — successful runs keep memory
-        flat. On a non-zero exit raises ``CalledProcessError`` carrying the
-        collected stderr (and stdout) so the caller can build ``FFmpegError``.
+        ``run()``. Only a bounded tail of stderr is retained (in the shared
+        :class:`~ffmpeg_wrap._textio.TeePump`), and it is decoded and joined
+        solely on the failure path — successful runs keep memory flat. On a
+        non-zero exit raises ``CalledProcessError`` carrying the collected
+        stderr (and stdout) so the caller can build ``FFmpegError``.
         """
         encoding = locale.getpreferredencoding(False)
-        # ``sys.stderr`` is normally a text wrapper over a binary ``.buffer``,
-        # which takes the raw byte chunks directly. When the active
-        # ``sys.stderr`` is text-only (no ``.buffer`` — e.g. a capturing
-        # wrapper) or ``None``, fall back and decode per chunk so the live tee
-        # is preserved instead of silently dropped on a bytes-to-text write.
-        buffer = getattr(sys.stderr, "buffer", None)
-        if buffer is not None:
-            sink, sink_is_text = buffer, False
-        else:
-            sink, sink_is_text = sys.stderr, True
-        tail: collections.deque[bytes] = collections.deque()
-        tail_len = 0
+        pump_state = TeePump(encoding)
 
         def _pump(stream: Any) -> None:
-            nonlocal tail_len
+            # Only the read loop lives here; per-chunk forwarding + bounded-tail
+            # bookkeeping are owned by the shared ``TeePump`` (same code the
+            # async tee task feeds).
             reader = stream.read1 if hasattr(stream, "read1") else stream.read
             while True:
                 chunk = reader(65536)
                 if not chunk:
                     break
-                try:
-                    # Forward raw bytes (or a lenient per-chunk decode for a
-                    # text-only sink) WITHOUT newline translation, so ffmpeg's
-                    # ``\r`` progress updates still overwrite in place on the
-                    # terminal rather than scrolling.
-                    sink.write(chunk.decode(encoding, errors="replace") if sink_is_text else chunk)
-                    sink.flush()
-                except (OSError, ValueError, TypeError, AttributeError):
-                    pass
-                tail.append(chunk)
-                tail_len += len(chunk)
-                while tail_len > FFmpeg._STDERR_TAIL_BYTES and len(tail) > 1:
-                    tail_len -= len(tail.popleft())
+                pump_state.feed(chunk)
             stream.close()
 
         with subprocess.Popen(cmd, stdout=stdout_dest, stderr=subprocess.PIPE) as process:
@@ -500,13 +727,13 @@ class FFmpeg:
             pump.join()
 
         # The returned stdout and ``FFmpegError.stderr`` mirror
-        # ``subprocess.run(text=True)`` (see ``_decode_text``): platform-default
+        # ``subprocess.run(text=True)`` (see ``decode_text``): platform-default
         # encoding with universal-newline translation, leniently decoded.
         if text and isinstance(stdout_data, bytes):
-            stdout_data = FFmpeg._decode_text(stdout_data, encoding)
+            stdout_data = decode_text(stdout_data, encoding)
         if process.returncode:
-            stderr_bytes = b"".join(tail)
-            stderr_data: bytes | str = FFmpeg._decode_text(stderr_bytes, encoding) if text else stderr_bytes
+            stderr_bytes = pump_state.tail_bytes()
+            stderr_data: bytes | str = decode_text(stderr_bytes, encoding) if text else stderr_bytes
             raise subprocess.CalledProcessError(process.returncode, cmd, output=stdout_data, stderr=stderr_data)
         return stdout_data
 
@@ -531,13 +758,26 @@ def _convert_arg(key: str, value: Any) -> list[str]:
 def input(filename: str | os.PathLike[str], ffmpeg_path: str = "ffmpeg", **kwargs: Any) -> FFmpeg:
     """Start a new FFmpeg chain with an input file.
 
+    This is the recommended entry point for building a fluent chain. It creates
+    a fresh :class:`FFmpeg` instance and calls :meth:`~FFmpeg.input` on it.
+
     Args:
         filename: Input file path or PathLike object.
-        ffmpeg_path: Path to the ffmpeg executable.
-        **kwargs: Input arguments.
+        ffmpeg_path: Path to the ffmpeg executable. Defaults to ``"ffmpeg"``
+            (resolved from ``PATH``).
+        **kwargs: FFmpeg input options passed through to the input slot
+            (e.g. ``ss=30``, ``t=60``).
 
     Returns:
-        A new FFmpeg wrapper instance with the input added.
+        A new :class:`FFmpeg` instance with the input added, ready for further
+        chaining.
+
+    Example:
+        ```python
+        from ffmpeg_wrap import input
+
+        input("in.mkv", ss=30, t=60).output("clip.mp4").codec("v", "copy").run()
+        ```
     """
     instance = FFmpeg(ffmpeg_path=ffmpeg_path)
     return instance.input(filename, **kwargs)

--- a/src/ffmpeg_wrap/_encoders.py
+++ b/src/ffmpeg_wrap/_encoders.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import subprocess
 
-from ._errors import FFmpegError
+from ffmpeg_wrap._errors import _build_ffmpeg_error
 
 logger = logging.getLogger("ffmpeg_wrap")
 
@@ -35,6 +35,11 @@ def _parse_encoders(output: str) -> frozenset[str]:
     return frozenset(names)
 
 
+def _build_encoders_cmd(ffmpeg_path: str = "ffmpeg") -> list[str]:
+    """Build the ``ffmpeg -encoders`` command (pure; shared by sync/async)."""
+    return [ffmpeg_path, "-hide_banner", "-encoders"]
+
+
 def encoders(ffmpeg_path: str = "ffmpeg") -> frozenset[str]:
     """Return the set of encoder names reported by ``ffmpeg -encoders``.
 
@@ -49,19 +54,28 @@ def encoders(ffmpeg_path: str = "ffmpeg") -> frozenset[str]:
 
     Raises:
         FFmpegError: If ffmpeg cannot be run or exits non-zero.
+
+    Example:
+        ```python
+        import ffmpeg_wrap as ffmpeg
+
+        available = ffmpeg.encoders()
+        print("libx264" in available)   # True if ffmpeg was compiled with it
+        print(sorted(available)[:5])    # first five encoder names alphabetically
+        ```
     """
     cached = _ENCODERS_CACHE.get(ffmpeg_path)
     if cached is not None:
         return cached
 
-    cmd = [ffmpeg_path, "-hide_banner", "-encoders"]
+    cmd = _build_encoders_cmd(ffmpeg_path)
     try:
         result = subprocess.run(cmd, capture_output=True, check=True, text=True)
     except subprocess.CalledProcessError as e:
         stderr_text = e.stderr if isinstance(e.stderr, str) else None
         err_msg = stderr_text or str(e)
         logger.error(f"ffmpeg -encoders failed: {err_msg}")
-        raise FFmpegError(
+        raise _build_ffmpeg_error(
             f"ffmpeg -encoders error: {err_msg}",
             stderr=stderr_text,
             returncode=e.returncode,
@@ -69,7 +83,7 @@ def encoders(ffmpeg_path: str = "ffmpeg") -> frozenset[str]:
         ) from e
     except OSError as e:
         logger.error(f"ffmpeg could not be executed: {e}")
-        raise FFmpegError(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+        raise _build_ffmpeg_error(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
 
     parsed = _parse_encoders(result.stdout)
     _ENCODERS_CACHE[ffmpeg_path] = parsed
@@ -84,10 +98,21 @@ def has_encoder(name: str, ffmpeg_path: str = "ffmpeg") -> bool:
         ffmpeg_path: Path to the ffmpeg executable.
 
     Returns:
-        True iff ``name`` appears in :func:`encoders`.
+        ``True`` iff ``name`` appears in :func:`encoders`.
 
     Raises:
         FFmpegError: If ffmpeg cannot be run or exits non-zero.
+
+    Example:
+        ```python
+        import ffmpeg_wrap as ffmpeg
+
+        if ffmpeg.has_encoder("h264_nvenc"):
+            codec = "h264_nvenc"
+        else:
+            codec = "libx264"
+        ffmpeg.input("in.mkv").output("out.mp4").codec("v", codec).run()
+        ```
     """
     return name in encoders(ffmpeg_path)
 

--- a/src/ffmpeg_wrap/_errors.py
+++ b/src/ffmpeg_wrap/_errors.py
@@ -9,9 +9,25 @@ class FFmpegError(Exception):
     ``str(e)``. The message remains ``args[0]`` so ``str(e)`` is unchanged.
 
     Attributes:
-        stderr: Decoded stderr from the failed process, if captured.
-        returncode: Process exit code, if available.
-        cmd: The command that was executed, if available.
+        stderr: Decoded stderr from the failed process, or ``None`` if not
+            captured. Present on both :meth:`~ffmpeg_wrap.FFmpeg.run` failures
+            and :func:`~ffmpeg_wrap.probe` / :func:`~ffmpeg_wrap.validate`
+            failures.
+        returncode: Process exit code, or ``None`` when the process could not
+            be launched at all (e.g. executable not found).
+        cmd: The exact command list that was executed, or ``None``.
+
+    Example:
+        ```python
+        import ffmpeg_wrap as ffmpeg
+
+        try:
+            ffmpeg.input("missing.mkv").output("out.mp4").run()
+        except ffmpeg.FFmpegError as e:
+            print("exit code:", e.returncode)
+            print("command:", e.cmd)
+            print("stderr:", e.stderr)
+        ```
     """
 
     def __init__(
@@ -26,3 +42,20 @@ class FFmpegError(Exception):
         self.stderr = stderr
         self.returncode = returncode
         self.cmd = cmd
+
+
+def _build_ffmpeg_error(
+    message: str,
+    *,
+    stderr: str | None = None,
+    returncode: int | None = None,
+    cmd: list[str] | None = None,
+) -> FFmpegError:
+    """Construct an :class:`FFmpegError` from an already-formatted message.
+
+    Single shared constructor for every failure path (sync ``run``/``probe``/
+    ``validate``/``encoders`` and their async twins). The message prefix
+    (``"ffmpeg error: ..."`` vs ``"ffprobe error: ..."``) is built at each call
+    site; this helper only wires the structured introspection fields.
+    """
+    return FFmpegError(message, stderr=stderr, returncode=returncode, cmd=cmd)

--- a/src/ffmpeg_wrap/_filters.py
+++ b/src/ffmpeg_wrap/_filters.py
@@ -20,9 +20,16 @@ def filter_arg_escape(value: str) -> str:
     the filter-option parser and splits the value, so the backslash escaping is
     required as well. The result parses back to the original ``value``.
 
-    Typical use is building a ``subtitles=`` (or any path-bearing) filter::
+    Typical use is building a ``subtitles=`` (or any path-bearing) filter.
 
+    Example:
+        ```python
+        from ffmpeg_wrap import filter_arg_escape, input
+
+        path = "/media/My Film: Director's Cut/subs.srt"
         graph = f"subtitles={filter_arg_escape(path)}"
+        input("in.mkv").filter_complex(graph).output("out.mp4").run()
+        ```
 
     Args:
         value: The raw string to escape (e.g. a filesystem path).

--- a/src/ffmpeg_wrap/_probe.py
+++ b/src/ffmpeg_wrap/_probe.py
@@ -17,7 +17,7 @@ else:  # Python 3.10: StrEnum was added in 3.11
 
 import msgspec
 
-from ._errors import FFmpegError
+from ffmpeg_wrap._errors import _build_ffmpeg_error
 
 logger = logging.getLogger("ffmpeg_wrap")
 
@@ -30,6 +30,21 @@ class CodecType(StrEnum):
     this enum: ffmpeg can report ``codec_type`` values outside this set, and
     decoding into a strict enum would raise ``msgspec.ValidationError`` on such
     files. Compare against these members instead of retyping the field.
+
+    Attributes:
+        VIDEO: Represents a video stream (``"video"``).
+        AUDIO: Represents an audio stream (``"audio"``).
+        SUBTITLE: Represents a subtitle stream (``"subtitle"``).
+        DATA: Represents a data stream (``"data"``).
+        ATTACHMENT: Represents an attachment stream (``"attachment"``).
+
+    Example:
+        ```python
+        from ffmpeg_wrap import CodecType, probe
+
+        result = probe("video.mkv")
+        videos = [s for s in result.streams if s.codec_type == CodecType.VIDEO]
+        ```
     """
 
     VIDEO = "video"
@@ -154,7 +169,47 @@ def _resolve_input(filename: str | os.PathLike[str]) -> str:
 
 
 class Stream(msgspec.Struct):
-    """A single stream from ffprobe output."""
+    """A single stream entry from ffprobe JSON output.
+
+    Decoded by ``msgspec`` from the ffprobe ``streams`` array. All fields
+    except :attr:`index` are optional because ffprobe omits irrelevant fields
+    per stream type (e.g. ``width``/``height`` are absent on audio streams).
+
+    Attributes:
+        index: Absolute stream index within the file (0-based).
+        codec_name: Short codec name as reported by ffprobe (e.g.
+            ``"h264"``, ``"aac"``, ``"subrip"``). ``None`` if not reported.
+        codec_type: Stream type string (e.g. ``"video"``, ``"audio"``,
+            ``"subtitle"``). ``None`` if not reported. Compare against
+            :class:`CodecType` members rather than raw strings.
+        width: Video frame width in pixels. ``None`` for non-video streams.
+        height: Video frame height in pixels. ``None`` for non-video streams.
+        channels: Number of audio channels. ``None`` for non-audio streams.
+        sample_rate: Audio sample rate as a string (e.g. ``"48000"``).
+            ``None`` for non-audio streams.
+        duration: Stream duration as a decimal-seconds string (e.g.
+            ``"3600.123000"``). ``None`` or ``"N/A"`` when unavailable.
+        bit_rate: Stream bit rate as a string (e.g. ``"128000"``).
+            ``None`` when not reported.
+        tags: Key/value metadata tags from the stream header (e.g.
+            ``{"language": "eng", "title": "Commentary"}``). ``None`` when
+            no tags are present.
+        disposition: ffprobe disposition flags as a ``dict[str, int]``
+            (e.g. ``{"default": 1, "forced": 0}``). ``None`` when absent.
+        type_index: Zero-based ordinal of this stream within its
+            :attr:`codec_type` group (the ``N`` in the ffmpeg specifier
+            ``0:<type>:N``). Set by :func:`probe`; defaults to ``0`` when a
+            ``Stream`` is constructed outside of :func:`probe`.
+
+    Example:
+        ```python
+        from ffmpeg_wrap import probe
+
+        result = probe("video.mkv")
+        for stream in result.streams:
+            print(stream.index, stream.codec_type, stream.codec_name)
+        ```
+    """
 
     index: int
     codec_name: str | None = None
@@ -185,6 +240,16 @@ class Stream(msgspec.Struct):
 
         Returns:
             The map specifier string.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            sub = next(s for s in result.streams if s.is_subtitle)
+            print(sub.map_specifier())   # e.g. "0:s:0"
+            print(sub.map_specifier(1))  # e.g. "1:s:0"
+            ```
         """
         letter = _STREAM_TYPE_LETTERS.get(self.codec_type or "")
         if letter is None:
@@ -196,32 +261,105 @@ class Stream(msgspec.Struct):
 
         Returns ``None`` when ``duration`` is missing or non-numeric
         (e.g. ``"N/A"``); the raw ``duration`` string is preserved.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            for stream in result.streams:
+                secs = stream.duration_seconds()
+                if secs is not None:
+                    print(f"stream {stream.index}: {secs:.1f}s")
+            ```
         """
         return _parse_duration(self.duration)
 
     @property
     def is_video(self) -> bool:
-        """True iff ``codec_type`` is ``"video"``."""
+        """True iff ``codec_type`` is ``"video"``.
+
+        Returns:
+            ``True`` for video streams, ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            videos = [s for s in result.streams if s.is_video]
+            audios = [s for s in result.streams if s.is_audio]
+            subs = [s for s in result.streams if s.is_subtitle]
+            ```
+        """
         return self.codec_type == CodecType.VIDEO
 
     @property
     def is_audio(self) -> bool:
-        """True iff ``codec_type`` is ``"audio"``."""
+        """True iff ``codec_type`` is ``"audio"``.
+
+        Returns:
+            ``True`` for audio streams, ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            audio_streams = [s for s in result.streams if s.is_audio]
+            ```
+        """
         return self.codec_type == CodecType.AUDIO
 
     @property
     def is_subtitle(self) -> bool:
-        """True iff ``codec_type`` is ``"subtitle"``."""
+        """True iff ``codec_type`` is ``"subtitle"``.
+
+        Returns:
+            ``True`` for subtitle streams, ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            subtitle_streams = [s for s in result.streams if s.is_subtitle]
+            ```
+        """
         return self.codec_type == CodecType.SUBTITLE
 
     @property
     def is_data(self) -> bool:
-        """True iff ``codec_type`` is ``"data"``."""
+        """True iff ``codec_type`` is ``"data"``.
+
+        Returns:
+            ``True`` for data streams, ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            data_streams = [s for s in result.streams if s.is_data]
+            ```
+        """
         return self.codec_type == CodecType.DATA
 
     @property
     def is_attachment(self) -> bool:
-        """True iff ``codec_type`` is ``"attachment"``."""
+        """True iff ``codec_type`` is ``"attachment"``.
+
+        Returns:
+            ``True`` for attachment streams, ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            attachments = [s for s in result.streams if s.is_attachment]
+            ```
+        """
         return self.codec_type == CodecType.ATTACHMENT
 
     @property
@@ -230,6 +368,18 @@ class Stream(msgspec.Struct):
 
         Best-effort: driven by a documented codec-name set (``subrip``,
         ``ass``, ``ssa``, ...). Unknown subtitle codecs return ``False``.
+
+        Returns:
+            ``True`` for text-based subtitle streams (SRT, ASS, WebVTT, etc.),
+            ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            text_subs = [s for s in result.streams if s.is_text_subtitle]
+            ```
         """
         return self.is_subtitle and self.codec_name in _TEXT_SUBTITLE_CODECS
 
@@ -240,12 +390,55 @@ class Stream(msgspec.Struct):
         Best-effort: driven by a documented codec-name set
         (``hdmv_pgs_subtitle``, ``dvd_subtitle``, ``dvb_subtitle``, ...).
         Unknown subtitle codecs return ``False``.
+
+        Returns:
+            ``True`` for bitmap/image subtitle streams (PGS, DVD, DVB, etc.),
+            ``False`` otherwise.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            image_subs = [s for s in result.streams if s.is_image_subtitle]
+            ```
         """
         return self.is_subtitle and self.codec_name in _IMAGE_SUBTITLE_CODECS
 
 
 class Format(msgspec.Struct):
-    """The format section from ffprobe output."""
+    """The format/container section from ffprobe JSON output.
+
+    Decoded from the top-level ``"format"`` key of ffprobe's JSON output.
+    All fields are optional because ffprobe may omit them for certain inputs.
+
+    Attributes:
+        filename: Resolved path of the probed file as reported by ffprobe.
+        nb_streams: Total number of streams in the container.
+        nb_programs: Number of programs (relevant for MPEG-TS and similar).
+        format_name: Short format/muxer name (e.g. ``"matroska,webm"``).
+        format_long_name: Human-readable format name (e.g.
+            ``"Matroska / WebM"``).
+        start_time: Container start time in decimal seconds (e.g.
+            ``"0.000000"``). ``None`` when not reported.
+        duration: Container duration in decimal seconds (e.g.
+            ``"3600.123000"``). ``None`` or ``"N/A"`` when unavailable.
+        size: File size in bytes as a string (e.g. ``"1234567890"``).
+        bit_rate: Overall container bit rate in bits/s as a string.
+        probe_score: ffprobe format-detection confidence score (0-100).
+        tags: Container-level metadata tags (e.g.
+            ``{"title": "My Movie", "encoder": "Lavf58.76.100"}``).
+
+    Example:
+        ```python
+        from ffmpeg_wrap import probe
+
+        result = probe("video.mkv")
+        fmt = result.format
+        if fmt:
+            print(fmt.format_name, fmt.duration_seconds())
+        ```
+    """
 
     filename: str | None = None
     nb_streams: int | None = None
@@ -264,12 +457,42 @@ class Format(msgspec.Struct):
 
         Returns ``None`` when ``duration`` is missing or non-numeric
         (e.g. ``"N/A"``); the raw ``duration`` string is preserved.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            if result.format:
+                secs = result.format.duration_seconds()
+                print(f"Duration: {secs:.1f}s" if secs else "Unknown duration")
+            ```
         """
         return _parse_duration(self.duration)
 
 
 class ProbeResult(msgspec.Struct):
-    """Typed result of running ffprobe on a file."""
+    """Typed result of running :func:`probe` on a media file.
+
+    Top-level container decoded from ffprobe's ``-print_format json`` output.
+    Provides convenient access to all streams and the container format
+    information in a single structured object.
+
+    Attributes:
+        streams: All streams found in the file, in index order. Each entry is
+            a :class:`Stream` with ``type_index`` populated by :func:`probe`.
+        format: Container-level format information, or ``None`` when ffprobe
+            did not emit a ``"format"`` section (rare for well-formed files).
+
+    Example:
+        ```python
+        from ffmpeg_wrap import probe
+
+        result = probe("video.mkv")
+        print(result.format.format_name if result.format else None)
+        print([s.codec_name for s in result.streams if s.is_video])
+        ```
+    """
 
     streams: list[Stream]
     format: Format | None = None
@@ -279,6 +502,15 @@ class ProbeResult(msgspec.Struct):
 
         Delegates to ``self.format``; returns ``None`` when ``format`` is
         absent or its ``duration`` is missing/non-numeric.
+
+        Example:
+            ```python
+            from ffmpeg_wrap import probe
+
+            result = probe("video.mkv")
+            secs = result.duration_seconds()
+            print(f"Duration: {secs:.1f}s" if secs else "Duration unknown")
+            ```
         """
         if self.format is None:
             return None
@@ -294,6 +526,72 @@ def _assign_type_indices(streams: list[Stream]) -> None:
         counters[stream.codec_type] = ordinal + 1
 
 
+def _build_validate_cmd(
+    filename: str | os.PathLike[str],
+    ffprobe_path: str = "ffprobe",
+    loglevel: str = "warning",
+    extra_args: tuple[str, ...] = (),
+) -> list[str]:
+    """Build the ffprobe validation command (pure; shared by sync/async).
+
+    The loglevel precondition lives HERE so it is written once and both shells
+    let the ``ValueError`` propagate.
+
+    Raises:
+        ValueError: If ``loglevel`` is not a known ffprobe loglevel keyword.
+    """
+    if loglevel not in _FFPROBE_LOGLEVELS:
+        msg = f"invalid loglevel {loglevel!r}, must be one of: {', '.join(sorted(_FFPROBE_LOGLEVELS))}"
+        raise ValueError(msg)
+    filename_str = _resolve_input(filename)
+    return [ffprobe_path, "-v", loglevel, *[str(a) for a in extra_args], filename_str]
+
+
+def _interpret_validate(returncode: int, stderr_bytes: bytes) -> tuple[bool, str]:
+    """Interpret a completed ffprobe validation run (pure; shared by sync/async).
+
+    Returns ``(ok, stderr_text)`` where ``ok`` is True iff the exit code is 0
+    AND the decoded stderr is empty after stripping.
+    """
+    stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+    ok = returncode == 0 and not stderr_text.strip()
+    return (ok, stderr_text)
+
+
+def _build_probe_cmd(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> list[str]:
+    """Build the ffprobe JSON-introspection command (pure; shared by sync/async)."""
+    filename_str = _resolve_input(filename)
+    return [
+        ffprobe_path,
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        filename_str,
+    ]
+
+
+def _parse_probe_output(stdout: bytes, cmd: list[str]) -> ProbeResult:
+    """Decode ffprobe JSON stdout into a ``ProbeResult`` (pure; shared by sync/async).
+
+    Performs the msgspec decode and per-type ordinal assignment. Raises
+    ``FFmpegError`` on a decode/validation failure; the OSError and
+    CalledProcessError handling stays in each I/O shell.
+
+    Raises:
+        FFmpegError: If the output cannot be parsed into a ``ProbeResult``.
+    """
+    try:
+        parsed = msgspec.json.decode(stdout, type=ProbeResult)
+    except (msgspec.DecodeError, msgspec.ValidationError) as e:
+        logger.error(f"Failed to parse ffprobe output: {e}")
+        raise _build_ffmpeg_error(f"ffprobe output parsing error: {e}", cmd=cmd) from e
+    _assign_type_indices(parsed.streams)
+    return parsed
+
+
 def validate(
     filename: str | os.PathLike[str],
     ffprobe_path: str = "ffprobe",
@@ -301,6 +599,10 @@ def validate(
     extra_args: tuple[str, ...] = (),
 ) -> tuple[bool, str]:
     """Run ffprobe in validation mode and report diagnostics.
+
+    Does **not** raise on bad media — a non-zero exit or non-empty stderr is a
+    normal outcome (returned as ``ok=False``). This makes it safe to use as a
+    boolean health-check without wrapping in ``try/except``.
 
     Args:
         filename: Path to the media file (str or PathLike).
@@ -315,27 +617,33 @@ def validate(
             is performed on these args.
 
     Returns:
-        (ok, stderr_text). ok is True iff ffprobe exit code == 0 AND
-        stderr.strip() is empty. stderr_text is the raw decoded stderr
-        (never None, possibly empty string).
+        ``(ok, stderr_text)`` where ``ok`` is ``True`` iff the ffprobe exit
+        code is 0 *and* ``stderr.strip()`` is empty. ``stderr_text`` is the
+        raw decoded stderr (never ``None``, possibly an empty string).
 
-    Does NOT raise on bad media — that is a normal outcome for a validator.
-    Raises FFmpegError only when the ffprobe executable cannot be run.
-    Raises ValueError on invalid loglevel.
+    Raises:
+        FFmpegError: Only when the ffprobe executable itself cannot be run
+            (e.g. not found on ``PATH``). A corrupt or unreadable media file
+            does *not* raise — it returns ``(False, stderr_text)``.
+        ValueError: If ``loglevel`` is not a recognised ffprobe loglevel
+            keyword.
+
+    Example:
+        ```python
+        import ffmpeg_wrap as ffmpeg
+
+        ok, diag = ffmpeg.validate("recording.mkv")
+        if not ok:
+            print("Validation failed:", diag)
+        ```
     """
-    if loglevel not in _FFPROBE_LOGLEVELS:
-        msg = f"invalid loglevel {loglevel!r}, must be one of: {', '.join(sorted(_FFPROBE_LOGLEVELS))}"
-        raise ValueError(msg)
-    filename_str = _resolve_input(filename)
-    cmd = [ffprobe_path, "-v", loglevel, *[str(a) for a in extra_args], filename_str]
+    cmd = _build_validate_cmd(filename, ffprobe_path, loglevel, extra_args)
     try:
         result = subprocess.run(cmd, capture_output=True, check=False, text=False)
     except OSError as e:
         logger.error(f"ffprobe could not be executed: {e}")
-        raise FFmpegError(f"ffprobe could not be executed: {e}", cmd=cmd) from e
-    stderr_text = result.stderr.decode("utf-8", errors="replace")
-    ok = result.returncode == 0 and not stderr_text.strip()
-    return (ok, stderr_text)
+        raise _build_ffmpeg_error(f"ffprobe could not be executed: {e}", cmd=cmd) from e
+    return _interpret_validate(result.returncode, result.stderr)
 
 
 def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> ProbeResult:
@@ -346,23 +654,23 @@ def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> Pr
         ffprobe_path: Path to the ffprobe executable.
 
     Returns:
-        Parsed and typed output from ffprobe.
+        Parsed and typed :class:`ProbeResult` containing all streams and
+        container format information.
 
     Raises:
-        FFmpegError: If ffprobe fails or output cannot be parsed.
-    """
-    filename_str = _resolve_input(filename)
+        FFmpegError: If ffprobe fails or the output cannot be parsed.
 
-    cmd = [
-        ffprobe_path,
-        "-v",
-        "quiet",
-        "-print_format",
-        "json",
-        "-show_format",
-        "-show_streams",
-        filename_str,
-    ]
+    Example:
+        ```python
+        import ffmpeg_wrap as ffmpeg
+
+        result = ffmpeg.probe("video.mkv")
+        print(result.format.format_name if result.format else None)
+        for stream in result.streams:
+            print(stream.index, stream.codec_type, stream.codec_name)
+        ```
+    """
+    cmd = _build_probe_cmd(filename, ffprobe_path)
     try:
         result = subprocess.run(
             cmd,
@@ -370,14 +678,11 @@ def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> Pr
             check=True,
             text=False,
         )
-        parsed = msgspec.json.decode(result.stdout, type=ProbeResult)
-        _assign_type_indices(parsed.streams)
-        return parsed
     except subprocess.CalledProcessError as e:
         stderr_text = e.stderr.decode("utf-8", errors="replace") if e.stderr else None
         err_msg = stderr_text or str(e)
         logger.error(f"ffprobe failed: {err_msg}")
-        raise FFmpegError(
+        raise _build_ffmpeg_error(
             f"ffprobe error: {err_msg}",
             stderr=stderr_text,
             returncode=e.returncode,
@@ -385,7 +690,5 @@ def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> Pr
         ) from e
     except OSError as e:
         logger.error(f"ffprobe could not be executed: {e}")
-        raise FFmpegError(f"ffprobe could not be executed: {e}", cmd=cmd) from e
-    except (msgspec.DecodeError, msgspec.ValidationError) as e:
-        logger.error(f"Failed to parse ffprobe output: {e}")
-        raise FFmpegError(f"ffprobe output parsing error: {e}", cmd=cmd) from e
+        raise _build_ffmpeg_error(f"ffprobe could not be executed: {e}", cmd=cmd) from e
+    return _parse_probe_output(result.stdout, cmd)

--- a/src/ffmpeg_wrap/_textio.py
+++ b/src/ffmpeg_wrap/_textio.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import collections
+import sys
+from typing import Any
+
+# Maximum stderr tail retained for ``FFmpegError`` (ffmpeg's diagnostics land at
+# the end of the stream, so a bounded tail keeps memory flat on long jobs while
+# still capturing the actionable error text).
+STDERR_TAIL_BYTES = 256 * 1024
+
+
+def decode_text(data: bytes, encoding: str) -> str:
+    """Decode tee-path bytes the way ``subprocess.run(text=True)`` returns text.
+
+    Mirrors subprocess's universal-newline translation (``\\r\\n`` and ``\\r``
+    collapse to ``\\n``) so the returned stdout and ``FFmpegError.stderr`` have
+    the same shape regardless of which ``run()`` path produced them. Decoding
+    stays lenient (``errors="replace"``) rather than subprocess's strict
+    default: a stray byte must never turn a finished run — or the error report
+    for a failed one — into a ``UnicodeDecodeError``.
+    """
+    return data.decode(encoding, errors="replace").replace("\r\n", "\n").replace("\r", "\n")
+
+
+class TeePump:
+    """Bounded-tail stderr forwarder shared by the sync and async tee paths.
+
+    Owns the per-chunk forward-to-sink logic and the bounded-tail ``deque``
+    state. Both the sync thread loop and the async task loop feed it raw byte
+    chunks via :meth:`feed`; only the *read loop* (``read1`` vs ``await
+    receive``) differs and stays in each shell.
+
+    The sink is resolved lazily at construction time. ``sys.stderr`` is normally
+    a text wrapper over a binary ``.buffer``, which takes the raw byte chunks
+    directly. When the active ``sys.stderr`` is text-only (no ``.buffer`` — e.g.
+    a capturing wrapper) or ``None``, fall back and decode per chunk so the live
+    tee is preserved instead of silently dropped on a bytes-to-text write.
+    """
+
+    def __init__(self, encoding: str, tail_limit: int = STDERR_TAIL_BYTES) -> None:
+        self._encoding = encoding
+        self._tail_limit = tail_limit
+        buffer = getattr(sys.stderr, "buffer", None)
+        if buffer is not None:
+            self._sink: Any = buffer
+            self._sink_is_text = False
+        else:
+            self._sink = sys.stderr
+            self._sink_is_text = True
+        self._tail: collections.deque[bytes] = collections.deque()
+        self._tail_len = 0
+
+    def feed(self, chunk: bytes) -> None:
+        """Forward ``chunk`` to the live sink and retain it in the bounded tail."""
+        try:
+            # Forward raw bytes (or a lenient per-chunk decode for a text-only
+            # sink) WITHOUT newline translation, so ffmpeg's ``\r`` progress
+            # updates still overwrite in place on the terminal rather than
+            # scrolling.
+            self._sink.write(chunk.decode(self._encoding, errors="replace") if self._sink_is_text else chunk)
+            self._sink.flush()
+        except (OSError, ValueError, TypeError, AttributeError):
+            pass
+        self._tail.append(chunk)
+        self._tail_len += len(chunk)
+        while self._tail_len > self._tail_limit and len(self._tail) > 1:
+            self._tail_len -= len(self._tail.popleft())
+
+    def tail_bytes(self) -> bytes:
+        """Return the retained bounded tail joined into a single ``bytes``."""
+        return b"".join(self._tail)

--- a/src/ffmpeg_wrap/aio.py
+++ b/src/ffmpeg_wrap/aio.py
@@ -1,0 +1,462 @@
+"""Asynchronous mirror of the public :mod:`ffmpeg_wrap` API, powered by AnyIO.
+
+Importing this module requires the optional ``[async]`` extra::
+
+    pip install ffmpeg-wrap[async]
+
+The coroutine mirrors live here so the core package stays dependency-free:
+``import ffmpeg_wrap`` never imports :mod:`anyio`. Each coroutine is a thin
+imperative shell over the *same* pure helpers the sync API uses — command
+building, output parsing, decoding and error construction are written once in
+the private modules and reused here; the only async-specific line is the
+``await anyio.run_process(...)`` exec call.
+"""
+
+from __future__ import annotations
+
+import locale
+import logging
+import os
+from subprocess import PIPE, CalledProcessError
+from typing import TYPE_CHECKING, Any, Literal, overload
+
+try:
+    import anyio
+except ImportError as exc:  # pragma: no cover - exercised via subprocess in tests
+    raise ImportError("install ffmpeg-wrap[async] to use ffmpeg_wrap.aio") from exc
+
+from ffmpeg_wrap._encoders import _ENCODERS_CACHE, _build_encoders_cmd, _parse_encoders
+from ffmpeg_wrap._errors import _build_ffmpeg_error
+from ffmpeg_wrap._probe import (
+    ProbeResult,
+    _build_probe_cmd,
+    _build_validate_cmd,
+    _interpret_validate,
+    _parse_probe_output,
+)
+from ffmpeg_wrap._textio import TeePump, decode_text
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ffmpeg_wrap._builder import FFmpeg
+
+logger = logging.getLogger("ffmpeg_wrap")
+
+__all__ = ["encoders", "has_encoder", "probe", "run", "validate"]
+
+
+def _decode_error_stderr(stderr: bytes | None, encoding: str, *, text: bool) -> str | None:
+    """Decode captured error stderr to match the sync ``run`` error path.
+
+    Parity rules (see ``_builder.run`` lines 411-414 and ``_builder._run_tee``):
+
+    * ``text=False`` — sync receives raw ``bytes`` and decodes them as UTF-8
+      with ``errors="replace"`` and NO universal-newline translation. We do the
+      identical thing so ``FFmpegError.stderr`` is byte-for-byte the same even
+      when the locale is not UTF-8 or stderr contains ffmpeg's ``\\r`` progress.
+    * ``text=True`` — sync's value already went through locale-decode plus
+      universal-newline translation; we mirror that via the lenient
+      :func:`decode_text` (the documented lenient-vs-strict edge for undecodable
+      bytes).
+    """
+    if stderr is None:
+        return None
+    if text:
+        return decode_text(stderr, encoding)
+    return stderr.decode("utf-8", errors="replace")
+
+
+async def probe(filename: str | os.PathLike[str], ffprobe_path: str = "ffprobe") -> ProbeResult:
+    """Run ffprobe asynchronously and return typed output.
+
+    Async mirror of :func:`ffmpeg_wrap.probe`. Reuses the shared command builder
+    and output parser; only the exec call is async.
+
+    Args:
+        filename: Path to the file to probe.
+        ffprobe_path: Path to the ffprobe executable.
+
+    Returns:
+        Parsed and typed output from ffprobe.
+
+    Raises:
+        FFmpegError: If ffprobe fails or output cannot be parsed.
+
+    Example:
+        ```python
+        import anyio
+        from ffmpeg_wrap import aio
+
+        async def main():
+            result = await aio.probe("video.mkv")
+            print(result.format.format_name if result.format else None)
+            for stream in result.streams:
+                print(stream.index, stream.codec_type, stream.codec_name)
+
+        anyio.run(main)
+        ```
+    """
+    cmd = _build_probe_cmd(filename, ffprobe_path)
+    try:
+        result = await anyio.run_process(cmd, check=False)
+    except OSError as e:
+        logger.error(f"ffprobe could not be executed: {e}")
+        raise _build_ffmpeg_error(f"ffprobe could not be executed: {e}", cmd=cmd) from e
+    if result.returncode != 0:
+        stderr_text = result.stderr.decode("utf-8", errors="replace") if result.stderr else None
+        # Empty-stderr fallback mirrors sync ``probe`` (``stderr_text or str(e)``
+        # where ``e`` is the ``CalledProcessError``) so ``str(FFmpegError)`` is
+        # identical across sync/async.
+        err_msg = stderr_text or str(CalledProcessError(result.returncode, cmd))
+        logger.error(f"ffprobe failed: {err_msg}")
+        raise _build_ffmpeg_error(
+            f"ffprobe error: {err_msg}",
+            stderr=stderr_text,
+            returncode=result.returncode,
+            cmd=cmd,
+        )
+    return _parse_probe_output(result.stdout, cmd)
+
+
+async def validate(
+    filename: str | os.PathLike[str],
+    ffprobe_path: str = "ffprobe",
+    loglevel: str = "warning",
+    extra_args: tuple[str, ...] = (),
+) -> tuple[bool, str]:
+    """Run ffprobe in validation mode asynchronously and report diagnostics.
+
+    Async mirror of :func:`ffmpeg_wrap.validate`. The loglevel precondition
+    lives in the shared command builder, so an invalid ``loglevel`` raises
+    ``ValueError`` exactly as in the sync path.
+
+    Args:
+        filename: Path to the media file (str or PathLike).
+        ffprobe_path: Path to the ffprobe executable.
+        loglevel: Value passed to ffprobe's ``-v`` flag (default ``"warning"``).
+        extra_args: Additional raw arguments forwarded to ffprobe before the
+            filename.
+
+    Returns:
+        ``(ok, stderr_text)`` — see :func:`ffmpeg_wrap.validate`. Does NOT raise
+        on bad media — that is a normal outcome for a validator.
+
+    Raises:
+        FFmpegError: Only when the ffprobe executable cannot be run.
+        ValueError: On an invalid ``loglevel``.
+
+    Example:
+        ```python
+        import anyio
+        from ffmpeg_wrap import aio
+
+        async def main():
+            ok, diag = await aio.validate("recording.mkv")
+            if not ok:
+                print("Validation failed:", diag)
+
+        anyio.run(main)
+        ```
+    """
+    cmd = _build_validate_cmd(filename, ffprobe_path, loglevel, extra_args)
+    try:
+        result = await anyio.run_process(cmd, check=False)
+    except OSError as e:
+        logger.error(f"ffprobe could not be executed: {e}")
+        raise _build_ffmpeg_error(f"ffprobe could not be executed: {e}", cmd=cmd) from e
+    return _interpret_validate(result.returncode, result.stderr)
+
+
+async def encoders(ffmpeg_path: str = "ffmpeg") -> frozenset[str]:
+    """Return the set of encoder names reported by ``ffmpeg -encoders``.
+
+    Async mirror of :func:`ffmpeg_wrap.encoders`. Shares the same per-path cache
+    (``_ENCODERS_CACHE``) as the sync API, so a value resolved by either path
+    populates one cache.
+
+    AnyIO's ``run_process`` always returns raw ``bytes``; we decode stdout as
+    UTF-8 before parsing so the result is ``frozenset[str]`` identical to sync
+    (``ffmpeg -encoders`` names are ASCII-only). The redundant-spawn race under
+    concurrent first-use is benign: the only ``await`` is the subprocess itself,
+    and the dict write is atomic.
+
+    Args:
+        ffmpeg_path: Path to the ffmpeg executable.
+
+    Returns:
+        A frozenset of encoder names (e.g. ``"libx264"``, ``"h264_nvenc"``).
+
+    Raises:
+        FFmpegError: If ffmpeg cannot be run or exits non-zero.
+
+    Example:
+        ```python
+        import anyio
+        from ffmpeg_wrap import aio
+
+        async def main():
+            available = await aio.encoders()
+            print("libx264" in available)
+
+        anyio.run(main)
+        ```
+    """
+    cached = _ENCODERS_CACHE.get(ffmpeg_path)
+    if cached is not None:
+        return cached
+
+    cmd = _build_encoders_cmd(ffmpeg_path)
+    try:
+        result = await anyio.run_process(cmd, check=False)
+    except OSError as e:
+        logger.error(f"ffmpeg could not be executed: {e}")
+        raise _build_ffmpeg_error(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+    if result.returncode != 0:
+        stderr_text = result.stderr.decode("utf-8", errors="replace") if result.stderr else None
+        # Empty-stderr fallback mirrors sync ``encoders`` (``stderr_text or str(e)``).
+        err_msg = stderr_text or str(CalledProcessError(result.returncode, cmd))
+        logger.error(f"ffmpeg -encoders failed: {err_msg}")
+        raise _build_ffmpeg_error(
+            f"ffmpeg -encoders error: {err_msg}",
+            stderr=stderr_text,
+            returncode=result.returncode,
+            cmd=cmd,
+        )
+
+    parsed = _parse_encoders(result.stdout.decode("utf-8", errors="replace"))
+    _ENCODERS_CACHE[ffmpeg_path] = parsed
+    return parsed
+
+
+async def has_encoder(name: str, ffmpeg_path: str = "ffmpeg") -> bool:
+    """Return whether ``name`` is an available ffmpeg encoder.
+
+    Async mirror of :func:`ffmpeg_wrap.has_encoder`.
+
+    Args:
+        name: Encoder name to check (e.g. ``"h264_nvenc"``).
+        ffmpeg_path: Path to the ffmpeg executable.
+
+    Returns:
+        ``True`` iff ``name`` appears in :func:`encoders`.
+
+    Raises:
+        FFmpegError: If ffmpeg cannot be run or exits non-zero.
+
+    Example:
+        ```python
+        import anyio
+        from ffmpeg_wrap import aio
+
+        async def main():
+            if await aio.has_encoder("h264_nvenc"):
+                print("NVENC is available")
+
+        anyio.run(main)
+        ```
+    """
+    return name in await encoders(ffmpeg_path)
+
+
+@overload
+async def run(
+    ffmpeg: FFmpeg,
+    capture_stdout: bool = ...,
+    capture_stderr: bool = ...,
+    *,
+    text: Literal[False] = ...,
+) -> tuple[bytes | None, bytes | None]: ...
+
+
+@overload
+async def run(
+    ffmpeg: FFmpeg,
+    capture_stdout: bool = ...,
+    capture_stderr: bool = ...,
+    *,
+    text: Literal[True],
+) -> tuple[str | None, str | None]: ...
+
+
+async def run(
+    ffmpeg: FFmpeg,
+    capture_stdout: bool = False,
+    capture_stderr: bool = False,
+    *,
+    text: bool = False,
+) -> tuple[bytes | None, bytes | None] | tuple[str | None, str | None]:
+    """Build and execute an :class:`~ffmpeg_wrap.FFmpeg` command asynchronously.
+
+    Async mirror of :meth:`ffmpeg_wrap.FFmpeg.run`, powered by AnyIO (runs on
+    both the asyncio and trio backends). The return contract is identical to the
+    sync ``run``: a ``(stdout, stderr)`` tuple of ``bytes`` (or ``str`` when
+    ``text=True``), with ``None`` for any stream that was not captured.
+
+    Two execution paths mirror sync:
+
+    * **Capture path** (``capture_stderr=True``): ``anyio.run_process`` captures
+      stderr (and stdout when ``capture_stdout`` is set), building ``FFmpegError``
+      on a non-zero exit.
+    * **Tee path** (``capture_stderr=False``): ffmpeg's stderr is forwarded live
+      to the inherited terminal via the shared :class:`~ffmpeg_wrap._textio.TeePump`
+      while only a bounded tail is retained for the failure path. This uses an
+      AnyIO task group instead of the sync version's OS pump thread — so on the
+      trio backend no per-process reaping thread is created either.
+
+    Args:
+        ffmpeg: The built :class:`~ffmpeg_wrap.FFmpeg` instance to execute.
+        capture_stdout: Whether to capture stdout (else inherit to terminal).
+        capture_stderr: Whether to capture stderr (else tee it live).
+        text: When True, decode stdout/stderr (and ``FFmpegError.stderr``) as
+            text leniently using the platform default encoding.
+
+    Returns:
+        Tuple of (stdout, stderr); see :meth:`ffmpeg_wrap.FFmpeg.run`.
+
+    Raises:
+        FFmpegError: If ffmpeg fails or cannot be executed.
+
+    Example:
+        ```python
+        import anyio
+        from ffmpeg_wrap import aio, input
+
+        async def main():
+            _, stderr = await aio.run(
+                input("in.mkv").output("out.mp4").overwrite_output(),
+                capture_stderr=True,
+                text=True,
+            )
+            print(stderr)
+
+        anyio.run(main)
+        ```
+    """
+    cmd = ffmpeg.compile()
+    stdout_dest = PIPE if capture_stdout else None
+
+    logger.debug(f"Running ffmpeg command (async): {' '.join(cmd)}")
+
+    if capture_stderr:
+        return await _run_capture(cmd, stdout_dest, text=text)
+    return await _run_tee(cmd, stdout_dest, text=text)
+
+
+async def _run_capture(
+    cmd: list[str],
+    stdout_dest: int | None,
+    *,
+    text: bool,
+) -> tuple[bytes | None, bytes | None] | tuple[str | None, str | None]:
+    """Capture-path exec: collect stderr (and optionally stdout) via run_process."""
+    encoding = locale.getpreferredencoding(False)
+    try:
+        result = await anyio.run_process(cmd, stdout=stdout_dest, stderr=PIPE, check=False)
+    except OSError as e:
+        logger.error(f"ffmpeg could not be executed: {e}")
+        raise _build_ffmpeg_error(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+
+    if result.returncode:
+        # ``run_process`` always returns raw bytes. Decode the error stderr the
+        # SAME way sync does for parity: on the ``text=False`` path sync receives
+        # bytes from ``subprocess.run`` and decodes them as UTF-8 with
+        # ``errors="replace"`` and NO newline translation (``_builder.run``
+        # lines 411-414); on the ``text=True`` path sync's value already went
+        # through locale-decode + universal newlines (mirrored by ``decode_text``).
+        stderr_text = _decode_error_stderr(result.stderr, encoding, text=text)
+        # Empty-stderr fallback mirrors sync ``run`` (``stderr_text or str(e)``
+        # where ``e`` is the ``CalledProcessError``) so ``str(FFmpegError)`` is
+        # byte-for-byte identical across sync/async.
+        err_msg = stderr_text or str(CalledProcessError(result.returncode, cmd))
+        logger.error(f"FFmpeg command failed: {err_msg}")
+        raise _build_ffmpeg_error(
+            f"ffmpeg error: {err_msg}",
+            stderr=stderr_text,
+            returncode=result.returncode,
+            cmd=cmd,
+        )
+
+    if text:
+        stdout = decode_text(result.stdout, encoding) if result.stdout is not None else None
+        stderr = decode_text(result.stderr, encoding) if result.stderr is not None else None
+        return stdout, stderr
+    # Guard: when stdout is not piped, ``result.stdout`` is None — never decode it.
+    return result.stdout, result.stderr
+
+
+async def _run_tee(
+    cmd: list[str],
+    stdout_dest: int | None,
+    *,
+    text: bool,
+) -> tuple[bytes | None, bytes | None] | tuple[str | None, str | None]:
+    """Tee-path exec: forward stderr live, accumulate stdout, no sync pump thread.
+
+    Mirrors the sync :meth:`ffmpeg_wrap.FFmpeg._run_tee` exactly except the read
+    loop is an AnyIO task instead of a daemon thread. This removes the dedicated
+    synchronous stderr-pump OS thread; this code does not itself spawn a
+    per-process thread, though the event-loop backend's child reaping may
+    (asyncio non-pidfd path) or may not (trio) use threads outside this code's
+    control. On the trio backend, the actual pipe-FD reads may still run on
+    AnyIO's bounded, shared worker-thread pool (not a thread per process). The shared
+    :class:`~ffmpeg_wrap._textio.TeePump` owns the per-chunk forward-to-sink and
+    bounded-tail bookkeeping (including the ``sys.stderr.buffer is None``
+    fallback), so the tee behavior is identical to sync.
+    """
+    encoding = locale.getpreferredencoding(False)
+    pump = TeePump(encoding)
+    stdout_buf = bytearray()
+
+    try:
+        process = await anyio.open_process(cmd, stdout=stdout_dest, stderr=PIPE, stdin=None)
+    except OSError as e:
+        logger.error(f"ffmpeg could not be executed: {e}")
+        raise _build_ffmpeg_error(f"ffmpeg could not be executed: {e}", cmd=cmd) from e
+
+    async def _drain(stream: Any, on_chunk: Callable[[bytes], object]) -> None:
+        # Shared read loop for both pipes — only the per-chunk action differs.
+        # ``ClosedResourceError`` is caught alongside ``EndOfStream`` so a read
+        # cancelled by task-group teardown never masks the original error.
+        if stream is None:
+            return
+        while True:
+            try:
+                chunk = await stream.receive(65536)
+            except (anyio.EndOfStream, anyio.ClosedResourceError):
+                break
+            on_chunk(chunk)
+
+    async with process, anyio.create_task_group() as tg:
+        tg.start_soon(_drain, process.stderr, pump.feed)
+        if stdout_dest is not None:
+            tg.start_soon(_drain, process.stdout, stdout_buf.extend)
+        tg.start_soon(process.wait)
+
+    stdout_data: bytes | None = bytes(stdout_buf) if stdout_dest is not None else None
+
+    stdout_result: bytes | str | None
+    if text and stdout_data is not None:
+        stdout_result = decode_text(stdout_data, encoding)
+    else:
+        stdout_result = stdout_data
+
+    if process.returncode:
+        # Match sync ``_run_tee`` + ``run`` error handling: text=False decodes
+        # the bounded tail as UTF-8/replace (no newline translation), text=True
+        # uses the locale ``decode_text``. See ``_decode_error_stderr``.
+        stderr_bytes = pump.tail_bytes()
+        stderr_text = _decode_error_stderr(stderr_bytes, encoding, text=text)
+        # Empty-stderr fallback mirrors sync ``_run_tee`` (which raises
+        # ``CalledProcessError`` that ``run`` formats via ``str(e)``) so
+        # ``str(FFmpegError)`` is byte-for-byte identical across sync/async.
+        err_msg = stderr_text or str(CalledProcessError(process.returncode, cmd))
+        logger.error(f"FFmpeg command failed: {err_msg}")
+        raise _build_ffmpeg_error(
+            f"ffmpeg error: {err_msg}",
+            stderr=stderr_text,
+            returncode=process.returncode,
+            cmd=cmd,
+        )
+
+    return stdout_result, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,20 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
+@pytest.fixture(params=["asyncio", "trio"], scope="module")
+def anyio_backend(request: pytest.FixtureRequest) -> str:
+    """Parametrize async tests over both AnyIO backends (asyncio and trio).
+
+    Module-scoped per AnyIO's requirement; async fixtures depending on it must
+    therefore be function- or module-scoped (never session-scoped). The trio
+    leg is skipped when trio is not installed so the suite still runs without
+    the ``[async]`` extra / dev group.
+    """
+    if request.param == "trio":
+        pytest.importorskip("trio")
+    return request.param
+
+
 @pytest.fixture(scope="session")
 def ffmpeg_available() -> None:
     """Skip the test unless both ffmpeg and ffprobe are on PATH."""

--- a/tests/test_aio_highload.py
+++ b/tests/test_aio_highload.py
@@ -1,0 +1,146 @@
+"""Task 5 tests: highload concurrency + lazy public ``aio`` export.
+
+The highload test launches many concurrent ``aio.probe()`` calls bounded by an
+``anyio.CapacityLimiter`` and asserts both that every call succeeds (matching the
+sync probe) and that the observed concurrency never exceeds the limiter bound.
+
+The export tests prove ``from ffmpeg_wrap import aio`` works via the PEP 562
+package ``__getattr__`` and that a bare ``import ffmpeg_wrap`` does NOT pull in
+anyio (checked in a fresh subprocess so an already-imported anyio in the test
+process can't mask a leak — mirrors ``tests/test_aio_packaging.py``).
+
+The whole module is skipped when ``anyio`` is not installed (so the suite still
+passes without the ``[async]`` extra).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("anyio")
+
+import anyio
+
+import ffmpeg_wrap as ffmpeg
+import ffmpeg_wrap.aio as aio
+
+
+class _ConcurrencyTracker:
+    """Track the peak number of simultaneously-active limited sections.
+
+    Robustness note: this mutates shared (``active``/``peak``) state without a
+    lock. That is safe here only because AnyIO runs the tasks cooperatively on a
+    single thread and there is NO ``await`` between :meth:`enter` and the peak
+    read (nor in :meth:`exit`), so no task switch can interleave a partial
+    update. Do not add an ``await`` inside these methods.
+    """
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+
+    def enter(self) -> None:
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+
+    def exit(self) -> None:
+        self.active -= 1
+
+
+class TestAioHighload:
+    async def test_bounded_concurrent_probe(self, real_file: Path) -> None:
+        n_jobs = 20
+        limit = 4
+        limiter = anyio.CapacityLimiter(limit)
+        tracker = _ConcurrencyTracker()
+        results: list[aio.ProbeResult] = []
+        expected = ffmpeg.probe(real_file)
+
+        async def one_probe() -> None:
+            async with limiter:
+                tracker.enter()
+                try:
+                    result = await aio.probe(real_file)
+                finally:
+                    tracker.exit()
+                results.append(result)
+
+        with anyio.fail_after(120):
+            async with anyio.create_task_group() as tg:
+                for _ in range(n_jobs):
+                    tg.start_soon(one_probe)
+
+        assert len(results) == n_jobs
+        assert all(r == expected for r in results)
+        # The CapacityLimiter must have kept observed concurrency within bound.
+        assert tracker.peak <= limit
+        assert tracker.peak >= 1
+
+
+def test_from_ffmpeg_wrap_import_aio() -> None:
+    """The PEP 562 ``__getattr__`` exposes ``aio`` as a package attribute."""
+    from ffmpeg_wrap import aio as exported
+
+    assert exported is aio
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import ffmpeg_wrap
+
+    with pytest.raises(AttributeError):
+        _ = ffmpeg_wrap.does_not_exist
+
+
+def test_core_import_does_not_import_anyio() -> None:
+    """``import ffmpeg_wrap`` must not import anyio until ``aio`` is accessed.
+
+    Run in a fresh subprocess so anyio already imported in this test process
+    can't mask a leak. After ``import ffmpeg_wrap`` anyio must be absent; after
+    accessing ``ffmpeg_wrap.aio`` it must be present.
+    """
+    code = (
+        "import sys\n"
+        "import ffmpeg_wrap\n"
+        "assert 'anyio' not in sys.modules, sorted(m for m in sys.modules if 'anyio' in m)\n"
+        "mod = ffmpeg_wrap.aio\n"
+        "assert 'anyio' in sys.modules\n"
+        "assert mod is ffmpeg_wrap.aio\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_wildcard_import_does_not_import_anyio() -> None:
+    """``from ffmpeg_wrap import *`` must not import anyio.
+
+    Regression guard for listing ``aio`` in ``__all__``: that would make the
+    wildcard import bind ``aio``, eagerly triggering ``__getattr__`` -> import
+    anyio and breaking ``import *`` when the optional ``[async]`` extra is not
+    installed. Run in a fresh subprocess so a pre-imported anyio can't mask a
+    leak.
+    """
+    code = (
+        "import sys\n"
+        "from ffmpeg_wrap import *\n"
+        "assert 'anyio' not in sys.modules, sorted(m for m in sys.modules if 'anyio' in m)\n"
+        "print('ok')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/test_aio_packaging.py
+++ b/tests/test_aio_packaging.py
@@ -1,0 +1,18 @@
+"""Task 1 packaging tests for the optional ``[async]`` extra.
+
+Verify that the ``ffmpeg_wrap.aio`` submodule is importable when ``anyio`` is
+installed. The zero-dependency-core invariant (``import ffmpeg_wrap`` must not
+pull in ``anyio`` until ``aio`` is accessed) is asserted by the richer
+``test_core_import_does_not_import_anyio`` in ``test_aio_highload.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_aio_submodule_importable() -> None:
+    pytest.importorskip("anyio")
+    import ffmpeg_wrap.aio as aio
+
+    assert aio is not None

--- a/tests/test_aio_probe.py
+++ b/tests/test_aio_probe.py
@@ -1,0 +1,115 @@
+"""Task 3 tests for the async ``ffmpeg_wrap.aio`` probe/validate/encoders API.
+
+These exercise the real ffmpeg/ffprobe binaries against the downloaded media
+fixtures. Every coroutine test is auto-promoted by ``anyio_mode = "auto"`` and
+runs on both AnyIO backends via the module-scoped ``anyio_backend`` fixture
+(asyncio + trio) defined in ``conftest.py``.
+
+The whole module is skipped cleanly when ``anyio`` is not installed (so the
+suite still passes without the ``[async]`` extra) and when ffmpeg/ffprobe are
+unavailable (via the existing ``ffmpeg_available``-backed fixtures).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("anyio")
+
+import ffmpeg_wrap as ffmpeg
+import ffmpeg_wrap.aio as aio
+from ffmpeg_wrap import FFmpegError
+from ffmpeg_wrap._encoders import _clear_encoders_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_encoders_cache() -> None:
+    """Keep the shared encoder cache clean across tests."""
+    _clear_encoders_cache()
+    yield
+    _clear_encoders_cache()
+
+
+class TestAioProbe:
+    async def test_probe_success(self, real_file: Path) -> None:
+        result = await aio.probe(real_file)
+        assert isinstance(result, aio.ProbeResult)
+        assert result.streams
+
+    async def test_probe_bad_path_raises(self, ffmpeg_available: None) -> None:
+        with pytest.raises(FFmpegError):
+            await aio.probe("/nonexistent/file/does-not-exist.mkv")
+
+    async def test_probe_missing_binary_raises(self, real_file: Path) -> None:
+        with pytest.raises(FFmpegError):
+            await aio.probe(real_file, ffprobe_path="ffprobe-does-not-exist")
+
+    async def test_probe_parity_with_sync(self, real_file: Path) -> None:
+        assert await aio.probe(real_file) == ffmpeg.probe(real_file)
+
+
+class TestAioValidate:
+    async def test_validate_success(self, real_file: Path) -> None:
+        ok, stderr = await aio.validate(real_file)
+        assert ok is True
+        assert stderr == ""
+
+    async def test_validate_bad_media_returns_false(self, bad_media: Path) -> None:
+        ok, stderr = await aio.validate(bad_media)
+        assert ok is False
+        assert isinstance(stderr, str)
+
+    async def test_validate_invalid_loglevel_raises(self) -> None:
+        # Pure-logic path: ValueError is raised by _build_validate_cmd before any
+        # subprocess, so this does not depend on ffmpeg being installed.
+        with pytest.raises(ValueError, match="invalid loglevel"):
+            await aio.validate("whatever.mkv", loglevel="bogus")
+
+    async def test_validate_missing_binary_raises(self, real_file: Path) -> None:
+        with pytest.raises(FFmpegError):
+            await aio.validate(real_file, ffprobe_path="ffprobe-does-not-exist")
+
+    async def test_validate_parity_with_sync(self, real_file: Path) -> None:
+        assert await aio.validate(real_file) == ffmpeg.validate(real_file)
+
+    async def test_validate_bad_media_parity_with_sync(self, bad_media: Path) -> None:
+        # ffmpeg embeds a nondeterministic context pointer in its diagnostics
+        # (``@ 0x811020000`` on Unix, ``@ 000002e074235680`` without the ``0x``
+        # prefix on Windows); normalise it before comparing so we assert on the
+        # meaningful stderr content, not the per-run heap address.
+        async_ok, async_err = await aio.validate(bad_media)
+        sync_ok, sync_err = ffmpeg.validate(bad_media)
+        ptr = re.compile(r"@ (?:0x)?[0-9a-fA-F]+")
+        assert async_ok == sync_ok
+        assert ptr.sub("@ 0xPTR", async_err) == ptr.sub("@ 0xPTR", sync_err)
+
+
+class TestAioEncoders:
+    async def test_encoders_success(self, ffmpeg_available: None) -> None:
+        result = await aio.encoders()
+        assert isinstance(result, frozenset)
+        assert result
+        assert all(isinstance(name, str) for name in result)
+
+    async def test_encoders_missing_binary_raises(self, ffmpeg_available: None) -> None:
+        with pytest.raises(FFmpegError):
+            await aio.encoders(ffmpeg_path="ffmpeg-does-not-exist")
+
+    async def test_has_encoder_true(self, ffmpeg_available: None) -> None:
+        # Pull a real encoder name from the listing, then assert membership.
+        names = await aio.encoders()
+        any_name = next(iter(names))
+        assert await aio.has_encoder(any_name) is True
+
+    async def test_has_encoder_false(self, ffmpeg_available: None) -> None:
+        assert await aio.has_encoder("definitely-not-a-real-encoder") is False
+
+    async def test_encoders_parity_with_sync(self, ffmpeg_available: None) -> None:
+        async_result = await aio.encoders()
+        _clear_encoders_cache()
+        sync_result = ffmpeg.encoders()
+        assert async_result == sync_result
+        assert all(isinstance(name, str) for name in async_result)

--- a/tests/test_aio_run.py
+++ b/tests/test_aio_run.py
@@ -1,0 +1,395 @@
+"""Task 4 tests for ``ffmpeg_wrap.aio.run`` and ``FFmpeg.arun``.
+
+These exercise the real ffmpeg binary against the downloaded media fixtures.
+Coroutine tests are auto-promoted by ``anyio_mode = "auto"`` and run on both
+AnyIO backends via the module-scoped ``anyio_backend`` fixture (asyncio + trio)
+defined in ``conftest.py``.
+
+The whole module is skipped cleanly when ``anyio`` is not installed and when
+ffmpeg/ffprobe are unavailable (via the ``ffmpeg_available``-backed fixtures).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("anyio")
+
+import anyio
+
+import ffmpeg_wrap as ffmpeg
+import ffmpeg_wrap.aio as aio
+from ffmpeg_wrap import FFmpegError
+
+
+def _failing_chain(real_file: Path) -> ffmpeg.FFmpeg:
+    """A command guaranteed to fail (bogus codec) on the given input."""
+    return ffmpeg.input(real_file, t=1).output("-", f="null").codec("v", "definitely-not-a-codec").overwrite_output()
+
+
+def _transcode_chain(real_file: Path, out: Path) -> ffmpeg.FFmpeg:
+    """A short, real transcode that succeeds and prints progress to stderr."""
+    return ffmpeg.input(real_file, t=1).output(str(out)).codec("v", "libx264").codec("a", "copy").overwrite_output()
+
+
+class TestAioRunCapture:
+    async def test_capture_stdout_and_stderr(self, real_file: Path) -> None:
+        # ``-f null -`` writes nothing to stdout but emits progress to stderr.
+        chain = ffmpeg.input(real_file, t=1).output("-", f="null").overwrite_output()
+        stdout, stderr = await aio.run(chain, capture_stdout=True, capture_stderr=True)
+        assert isinstance(stdout, bytes)
+        assert isinstance(stderr, bytes)
+
+    async def test_capture_stderr_only_returns_none_stdout(self, real_file: Path) -> None:
+        chain = ffmpeg.input(real_file, t=1).output("-", f="null").overwrite_output()
+        stdout, stderr = await aio.run(chain, capture_stderr=True)
+        assert stdout is None
+        assert isinstance(stderr, bytes)
+
+    async def test_capture_text_decodes(self, real_file: Path) -> None:
+        chain = ffmpeg.input(real_file, t=1).output("-", f="null").overwrite_output()
+        stdout, stderr = await aio.run(chain, capture_stdout=True, capture_stderr=True, text=True)
+        assert isinstance(stdout, str)
+        assert isinstance(stderr, str)
+
+    async def test_capture_error_raises_ffmpeg_error(self, real_file: Path) -> None:
+        with pytest.raises(FFmpegError) as exc:
+            await aio.run(_failing_chain(real_file), capture_stdout=True, capture_stderr=True)
+        assert exc.value.returncode not in (None, 0)
+        assert exc.value.stderr
+        assert exc.value.cmd is not None
+
+    async def test_capture_missing_binary_raises(self, real_file: Path) -> None:
+        chain = ffmpeg.FFmpeg(ffmpeg_path="ffmpeg-does-not-exist").input(real_file).output("-", f="null")
+        with pytest.raises(FFmpegError):
+            await aio.run(chain, capture_stderr=True)
+
+
+class TestAioRunTee:
+    async def test_tee_success(self, real_file: Path, tmp_path: Path) -> None:
+        out = tmp_path / "out.mp4"
+        stdout, stderr = await aio.run(_transcode_chain(real_file, out))
+        assert stdout is None
+        assert stderr is None
+        assert out.exists() and out.stat().st_size > 0
+
+    async def test_tee_capture_stdout(self, real_file: Path) -> None:
+        # Pipe a tiny stream to stdout while teeing stderr.
+        chain = ffmpeg.input(real_file, t=1).output("-", f="matroska", c="copy").map("0:v").overwrite_output()
+        stdout, stderr = await aio.run(chain, capture_stdout=True)
+        assert isinstance(stdout, bytes)
+        assert len(stdout) > 0
+        assert stderr is None
+
+    async def test_tee_error_raises_ffmpeg_error(self, real_file: Path) -> None:
+        with pytest.raises(FFmpegError) as exc:
+            await aio.run(_failing_chain(real_file))
+        assert exc.value.returncode not in (None, 0)
+        assert exc.value.stderr  # populated from the bounded tail
+        assert exc.value.cmd is not None
+
+
+class TestArun:
+    async def test_arun_delegates(self, real_file: Path, tmp_path: Path) -> None:
+        out = tmp_path / "out.mp4"
+        stdout, stderr = await _transcode_chain(real_file, out).arun()
+        assert stdout is None
+        assert stderr is None
+        assert out.exists() and out.stat().st_size > 0
+
+    async def test_arun_capture(self, real_file: Path) -> None:
+        chain = ffmpeg.input(real_file, t=1).output("-", f="null").overwrite_output()
+        stdout, stderr = await chain.arun(capture_stdout=True, capture_stderr=True)
+        assert isinstance(stdout, bytes)
+        assert isinstance(stderr, bytes)
+
+
+class TestFFmpegErrorParity:
+    async def test_error_parity_with_sync(self, real_file: Path) -> None:
+        # The same failing command should produce equivalent FFmpegError fields
+        # from both the sync and async capture paths.
+        with pytest.raises(FFmpegError) as sync_exc:
+            _failing_chain(real_file).run(capture_stdout=True, capture_stderr=True, text=True)
+        with pytest.raises(FFmpegError) as async_exc:
+            await aio.run(_failing_chain(real_file), capture_stdout=True, capture_stderr=True, text=True)
+
+        assert async_exc.value.returncode == sync_exc.value.returncode
+        assert async_exc.value.cmd == sync_exc.value.cmd
+        # The unknown-encoder diagnostic is deterministic for this command.
+        assert "definitely-not-a-codec" in (sync_exc.value.stderr or "")
+        assert "definitely-not-a-codec" in (async_exc.value.stderr or "")
+
+    async def test_error_parity_with_sync_text_false(self, real_file: Path) -> None:
+        # text=False parity: sync decodes the captured error bytes as
+        # UTF-8/replace with NO newline translation; async must produce the
+        # IDENTICAL FFmpegError.stderr (the plan's byte-for-byte parity claim).
+        with pytest.raises(FFmpegError) as sync_exc:
+            _failing_chain(real_file).run(capture_stdout=True, capture_stderr=True, text=False)
+        with pytest.raises(FFmpegError) as async_exc:
+            await aio.run(_failing_chain(real_file), capture_stdout=True, capture_stderr=True, text=False)
+
+        assert async_exc.value.returncode == sync_exc.value.returncode
+        assert async_exc.value.cmd == sync_exc.value.cmd
+        # Exact stderr equality after the SAME decode strategy on both paths.
+        # ffmpeg embeds a nondeterministic heap pointer per run (``@ 0x...`` on
+        # Unix, ``@ 000002...`` without the ``0x`` prefix on Windows), so
+        # normalise it before comparing — what we assert is that the decode
+        # (UTF-8/replace, no newline translation) is identical, not the pointer.
+        ptr = re.compile(r"@ (?:0x)?[0-9a-fA-F]+")
+        assert ptr.sub("@ 0xPTR", async_exc.value.stderr or "") == ptr.sub("@ 0xPTR", sync_exc.value.stderr or "")
+
+    async def test_empty_stderr_fallback_parity_with_sync(self, real_file: Path) -> None:
+        # Empty-stderr fallback parity (capture path): a command that fails with
+        # NO captured stderr must produce an IDENTICAL ``str(FFmpegError)`` on
+        # both paths. Sync uses ``stderr_text or str(e)`` (the CalledProcessError)
+        # → "Command '[...]' returned non-zero exit status N."; async must build
+        # the SAME message via ``str(CalledProcessError(...))`` — NOT a divergent
+        # "ffmpeg exited with code N".
+        def _silent_failing_chain() -> ffmpeg.FFmpeg:
+            # ``-loglevel quiet`` suppresses all stderr; the bogus codec still
+            # makes ffmpeg exit non-zero, so the capture path sees empty stderr.
+            return (
+                ffmpeg.input(real_file, t=1)
+                .global_args("-loglevel", "quiet")
+                .output("-", f="null")
+                .codec("v", "definitely-not-a-codec")
+                .overwrite_output()
+            )
+
+        with pytest.raises(FFmpegError) as sync_exc:
+            _silent_failing_chain().run(capture_stdout=True, capture_stderr=True)
+        with pytest.raises(FFmpegError) as async_exc:
+            await aio.run(_silent_failing_chain(), capture_stdout=True, capture_stderr=True)
+
+        assert async_exc.value.returncode == sync_exc.value.returncode
+        assert async_exc.value.cmd == sync_exc.value.cmd
+        # No stderr was captured on either path, so the fallback message drives
+        # ``str(FFmpegError)`` — assert it is byte-for-byte identical.
+        assert not sync_exc.value.stderr
+        assert not async_exc.value.stderr
+        assert str(async_exc.value) == str(sync_exc.value)
+        assert "returned non-zero exit status" in str(async_exc.value)
+
+    async def test_capture_text_decodes_leniently_on_non_utf8(self) -> None:
+        # Documented lenient-vs-strict edge: on undecodable bytes the async
+        # capture path decodes leniently (errors="replace") and never raises
+        # UnicodeDecodeError. Pipe raw non-UTF-8 bytes through a tiny shim that
+        # emits them on stdout, then capture with text=True.
+        chain = ffmpeg.FFmpeg(ffmpeg_path=sys.executable).global_args(
+            "-c",
+            "import sys; sys.stdout.buffer.write(bytes([255, 254, 128]) + b'abc')",
+        )
+        # This shim just writes raw non-UTF-8 bytes to stdout and exits 0.
+        # The key assertion is that capture+decode does NOT raise
+        # UnicodeDecodeError where strict sync decoding would.
+        stdout, _ = await aio.run(chain, capture_stdout=True, capture_stderr=True, text=True)
+        assert isinstance(stdout, str)
+        assert "abc" in stdout
+
+
+def test_no_per_process_reaping_thread_on_trio(real_file: Path, tmp_path: Path) -> None:
+    """trio reaps children WITHOUT a dedicated reaping thread.
+
+    The plan's claim is specifically about *child reaping*: on the asyncio
+    backend CPython adds a single per-process ``ThreadedChildWatcher`` thread,
+    while on trio reaping is handled by signal/``waitpid`` machinery with no
+    dedicated thread. (AnyIO's trio backend separately uses a bounded *reused*
+    worker-thread pool named ``Trio thread N`` for blocking pipe-FD I/O — that
+    is NOT a reaping thread; its scaling is asserted in the test below.)
+
+    Runs directly via ``anyio.run(..., backend="trio")`` (not the parametrized
+    fixture) so the assertion is trio-specific.
+    """
+    pytest.importorskip("trio")
+
+    out = tmp_path / "trio_out.mp4"
+    before = {t.name for t in threading.enumerate()}
+
+    async def _job() -> None:
+        await aio.run(_transcode_chain(real_file, out))
+
+    anyio.run(_job, backend="trio")
+
+    after = {t.name for t in threading.enumerate()}
+    new_threads = after - before
+    # No NEW persistent thread whose name suggests dedicated child reaping.
+    # NOTE: AnyIO's pooled "Trio thread N" workers are pipe-I/O workers, not
+    # reaping threads, so they are deliberately not in this token set.
+    suspicious = {
+        name
+        for name in new_threads
+        if any(token in name.lower() for token in ("waitpid", "child", "ffmpeg", "reap", "watcher"))
+    }
+    assert not suspicious, f"unexpected child-reaping thread(s) on trio: {suspicious}"
+    assert out.exists()
+
+
+def test_trio_worker_threads_bounded_by_concurrency_not_job_count(real_file: Path) -> None:
+    """trio's pipe-I/O worker pool scales with concurrency, not total jobs.
+
+    This guards the real thread-free claim: there is NO per-process thread that
+    grows one-per-job. AnyIO's trio backend uses a bounded, *reused* worker pool
+    for the blocking pipe-FD reads, so when we run many jobs through a small
+    ``CapacityLimiter`` the peak ``Trio thread N`` count tracks the limiter bound
+    (a small constant), not the (much larger) total job count.
+
+    Runs trio-only and directly via ``anyio.run`` so the assertion is specific
+    to the trio backend.
+    """
+    pytest.importorskip("trio")
+
+    n_jobs = 24
+    limit = 3
+
+    def _trio_worker_count() -> int:
+        return sum(1 for t in threading.enumerate() if t.name.startswith("Trio thread"))
+
+    peak = {"v": 0}
+    stop = threading.Event()
+
+    def _watch() -> None:
+        while not stop.is_set():
+            peak["v"] = max(peak["v"], _trio_worker_count())
+            stop.wait(0.002)
+
+    async def _job() -> None:
+        limiter = anyio.CapacityLimiter(limit)
+
+        async def _one() -> None:
+            async with limiter:
+                chain = ffmpeg.input(real_file, t=1).output("-", f="null").overwrite_output()
+                await aio.run(chain, capture_stderr=True)
+
+        async with anyio.create_task_group() as tg:
+            for _ in range(n_jobs):
+                tg.start_soon(_one)
+
+    watcher = threading.Thread(target=_watch, daemon=True)
+    watcher.start()
+    try:
+        anyio.run(_job, backend="trio")
+    finally:
+        stop.set()
+        watcher.join()
+
+    # Sublinear/bounded: peak worker threads stay near the concurrency bound, NOT
+    # near the job count. A generous ceiling (limit + small slack) still proves
+    # there is no per-job thread (which would push the peak toward ``n_jobs``).
+    assert peak["v"] <= limit + 2, (
+        f"trio worker-thread peak {peak['v']} grew with job count "
+        f"(n_jobs={n_jobs}, limit={limit}); expected it bounded by concurrency"
+    )
+
+
+class TestDeadlockAndFallback:
+    async def test_concurrent_read_no_deadlock(self, real_file: Path) -> None:
+        # Large output to BOTH stdout (piped matroska) and stderr (verbose
+        # progress). If the reader tasks did not run concurrently, the pipe
+        # buffers would fill and ffmpeg would deadlock — fail_after turns a hang
+        # into a fast failure instead of stalling the suite.
+        chain = (
+            ffmpeg.input(real_file)
+            .global_args("-loglevel", "verbose")
+            .output("-", f="matroska", c="copy")
+            .map("0:v")
+            .map("0:a")
+            .overwrite_output()
+        )
+        with anyio.fail_after(120):
+            stdout, stderr = await aio.run(chain, capture_stdout=True)
+        assert isinstance(stdout, bytes)
+        assert len(stdout) > 0
+        assert stderr is None
+
+    async def test_tee_error_propagates_real_error_not_closed_resource(self, real_file: Path) -> None:
+        # The failing tee run must surface the genuine FFmpegError, not a bare
+        # ClosedResourceError leaking from the cancelled stderr reader task.
+        with pytest.raises(FFmpegError):
+            await aio.run(_failing_chain(real_file))
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "asyncio's ProactorEventLoop cannot cancel a blocked subprocess pipe read on "
+            "Windows, so cancelling a tee mid-receive hangs instead of unwinding. Normal "
+            "aio.run — including the large-pipe deadlock case — works on Windows; only this "
+            "forced mid-read cancellation is unreliable there (an asyncio limitation, not a "
+            "library defect). Verified on Linux and macOS for both backends."
+        ),
+    )
+    async def test_tee_cancelled_midread_raises_cancel_not_closed_resource(self, real_file: Path) -> None:
+        # Cancel a long-running tee run WHILE its reader tasks are mid-receive
+        # (a timeout fires before ffmpeg finishes). This is the path that
+        # actually exercises aio.py's ClosedResourceError catch in the readers:
+        # the task group cancels the receivers and the process scope terminates
+        # the child. The surfaced outcome must be the cancellation/timeout, NOT
+        # a bare anyio.ClosedResourceError leaking out of a reader.
+        # A full-length libx264 *re-encode* (no -t, slow preset) is guaranteed to
+        # still be running when the short timeout fires, unlike a fast stream
+        # copy which finishes in milliseconds. ``-re`` is not needed — encoding
+        # the whole ~3 min input takes far longer than the timeout.
+        chain = (
+            ffmpeg.input(real_file)
+            .global_args("-loglevel", "verbose")
+            .output("-", f="matroska")
+            .codec("v", "libx264")
+            .codec("a", "copy")
+            .map("0:v")
+            .map("0:a")
+            .overwrite_output()
+        )
+        with pytest.raises(TimeoutError):
+            with anyio.fail_after(0.5):
+                await aio.run(chain, capture_stdout=True)
+        # Reaching here (TimeoutError, not ClosedResourceError) proves the catch
+        # works; fail_after raises TimeoutError on both AnyIO backends.
+
+    async def test_tee_failing_run_text_true_builds_str_stderr(self, real_file: Path) -> None:
+        # The text=True FAILING-tee path builds FFmpegError from
+        # pump.tail_bytes()+decode (aio.py ~346-356). Only text=False was
+        # covered before; assert the str stderr carries the diagnostic.
+        with pytest.raises(FFmpegError) as exc:
+            await aio.run(_failing_chain(real_file), text=True)
+        assert isinstance(exc.value.stderr, str)
+        assert "definitely-not-a-codec" in (exc.value.stderr or "")
+        assert exc.value.returncode not in (None, 0)
+
+    async def test_stderr_buffer_none_fallback(
+        self,
+        real_file: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Replace sys.stderr with a text-only sink lacking ``.buffer`` so the
+        # TeePump takes the per-chunk decode fallback path. The tee must still
+        # forward and the run must still complete.
+        class _TextOnlyStderr:
+            def __init__(self) -> None:
+                self.written: list[str] = []
+
+            def write(self, s: str) -> int:
+                self.written.append(s)
+                return len(s)
+
+            def flush(self) -> None:
+                pass
+
+        sink = _TextOnlyStderr()
+        monkeypatch.setattr(sys, "stderr", sink)
+
+        out = tmp_path / "fallback_out.mp4"
+        stdout, stderr = await aio.run(_transcode_chain(real_file, out))
+        assert stdout is None
+        assert stderr is None
+        assert out.exists() and out.stat().st_size > 0
+        # The text-only sink should have received the actual forwarded (decoded)
+        # ffmpeg diagnostics, not just an empty write — assert recognisable
+        # progress/banner markers appear in the joined output.
+        joined = "".join(sink.written)
+        assert joined.strip()
+        assert any(marker in joined for marker in ("frame", "size", "time", "ffmpeg version", "Stream"))

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -57,3 +57,14 @@ def test_all_exports_match():
         "filter_arg_escape",
     }
     assert set(ffmpeg.__all__) == expected
+
+
+def test_aio_not_in_all():
+    """``aio`` must NOT be in ``__all__``.
+
+    Listing it would make ``from ffmpeg_wrap import *`` eagerly import the
+    anyio-backed submodule, breaking wildcard import when the optional
+    ``[async]`` extra is not installed. ``import ffmpeg_wrap.aio`` and
+    ``from ffmpeg_wrap import aio`` still work via the lazy ``__getattr__``.
+    """
+    assert "aio" not in ffmpeg.__all__

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -5,6 +5,10 @@ argv (or escaped string) shown in the README, so the docs cannot drift away
 from the shipped behavior.
 """
 
+import inspect
+
+import pytest
+
 import ffmpeg_wrap as ffmpeg
 
 
@@ -169,3 +173,64 @@ def test_error_handling_attributes_documented():
     assert err.returncode == 1
     assert err.stderr == "boom"
     assert err.cmd == ["ffmpeg"]
+
+
+# --- Async API snippets ---------------------------------------------------
+#
+# The README "Async API" examples spawn real ffmpeg/ffprobe inside ``async def
+# main()`` bodies driven by ``anyio.run(...)``. We do NOT execute them here (no
+# event loop, no ffmpeg in the unit harness). Instead, matching this file's
+# convention, we validate the *static* contract the snippets rely on: the
+# documented builder chain still compiles to the expected argv, and the
+# ``aio``/``arun`` API surface exists with the documented signatures. The
+# anyio-dependent checks are guarded with ``importorskip`` so the suite still
+# passes without the optional ``[async]`` extra installed.
+
+
+def test_async_builder_chain_snippet_compiles():
+    """The README ``arun()`` example chain compiles to the documented argv.
+
+    The README awaits this exact chain; here we assert its synchronous
+    ``compile()`` argv so the documented command cannot drift.
+    """
+    cmd = ffmpeg.input("input.mkv").output("output.mp4", c="copy").overwrite_output().compile()
+    assert cmd == [
+        "ffmpeg",
+        "-y",
+        "-i",
+        "input.mkv",
+        "-c",
+        "copy",
+        "output.mp4",
+    ]
+
+
+def test_readme_async_imports_are_importable():
+    """``from ffmpeg_wrap import input`` and ``aio`` resolve as the README shows."""
+    pytest.importorskip("anyio")
+    from ffmpeg_wrap import aio
+
+    # README documents ``from ffmpeg_wrap import input`` for the async chain;
+    # access via the module to avoid shadowing the builtin in this test file.
+    assert callable(ffmpeg.input)
+    # Documented coroutine mirrors exist on the aio submodule.
+    for name in ("probe", "validate", "run", "encoders", "has_encoder"):
+        fn = getattr(aio, name)
+        assert inspect.iscoroutinefunction(fn), name
+
+
+def test_readme_arun_is_documented_coroutine():
+    """``FFmpeg.arun`` exists as a coroutine with the documented kwargs."""
+    pytest.importorskip("anyio")
+    builder = ffmpeg.input("input.mkv").output("output.mp4", c="copy")
+    assert inspect.iscoroutinefunction(builder.arun)
+    params = inspect.signature(builder.arun).parameters
+    assert set(params) == {"capture_stdout", "capture_stderr", "text"}
+
+
+def test_readme_capacity_limiter_pattern_available():
+    """The highload snippet's anyio primitives exist as documented."""
+    anyio = pytest.importorskip("anyio")
+    assert hasattr(anyio, "CapacityLimiter")
+    assert hasattr(anyio, "create_task_group")
+    assert hasattr(anyio, "run")

--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -1,0 +1,235 @@
+"""Tests for the extracted shared pure core (Task 2 refactor).
+
+These prove the shared helpers behave identically to the former inline logic and
+that ``FFmpegError`` objects produced by the sync paths are byte-for-byte
+unchanged (stderr/returncode/cmd).
+"""
+
+import collections
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ffmpeg_wrap._builder import FFmpeg
+from ffmpeg_wrap._encoders import _build_encoders_cmd
+from ffmpeg_wrap._errors import FFmpegError, _build_ffmpeg_error
+from ffmpeg_wrap._probe import (
+    _build_probe_cmd,
+    _build_validate_cmd,
+    _interpret_validate,
+    _parse_probe_output,
+    probe,
+    validate,
+)
+from ffmpeg_wrap._textio import STDERR_TAIL_BYTES, TeePump, decode_text
+
+
+class TestBuildFFmpegError:
+    def test_wires_all_fields(self):
+        err = _build_ffmpeg_error("ffmpeg error: boom", stderr="boom", returncode=2, cmd=["ffmpeg"])
+        assert isinstance(err, FFmpegError)
+        assert str(err) == "ffmpeg error: boom"
+        assert err.stderr == "boom"
+        assert err.returncode == 2
+        assert err.cmd == ["ffmpeg"]
+
+    def test_defaults_none(self):
+        err = _build_ffmpeg_error("ffprobe could not be executed: x", cmd=["ffprobe"])
+        assert err.stderr is None
+        assert err.returncode is None
+        assert err.cmd == ["ffprobe"]
+
+
+class TestDecodeText:
+    def test_matches_subprocess_universal_newlines(self):
+        assert decode_text(b"a\r\nb\rc\n", "utf-8") == "a\nb\nc\n"
+
+    def test_lenient_decode(self):
+        # Undecodable byte never raises; uses the replacement char.
+        assert decode_text(b"\xff", "utf-8") == "�"
+
+    def test_reexport_alias_identical(self):
+        assert FFmpeg._decode_text(b"x\r\ny", "utf-8") == decode_text(b"x\r\ny", "utf-8")
+        assert FFmpeg._STDERR_TAIL_BYTES == STDERR_TAIL_BYTES == 256 * 1024
+
+
+class TestTeePump:
+    def test_forwards_raw_bytes_to_buffer_sink(self):
+        fake_stderr = MagicMock()
+        with patch("ffmpeg_wrap._textio.sys.stderr", fake_stderr):
+            pump = TeePump("utf-8")
+            pump.feed(b"frame= 1\r")
+            pump.feed(b"frame= 2\n")
+        written = b"".join(c.args[0] for c in fake_stderr.buffer.write.call_args_list)
+        assert written == b"frame= 1\rframe= 2\n"
+        assert pump.tail_bytes() == b"frame= 1\rframe= 2\n"
+
+    def test_text_only_sink_decodes_per_chunk(self):
+        class _TextOnly:
+            buffer = None
+
+            def __init__(self):
+                self.written = []
+
+            def write(self, data):
+                if not isinstance(data, str):
+                    raise TypeError("must be str")
+                self.written.append(data)
+
+            def flush(self):
+                pass
+
+        fake = _TextOnly()
+        with patch("ffmpeg_wrap._textio.sys.stderr", fake):
+            pump = TeePump("utf-8")
+            pump.feed(b"frame= 10\r")
+        assert "".join(fake.written) == "frame= 10\r"
+
+    def test_bounded_tail_keeps_only_limit(self):
+        fake_stderr = MagicMock()
+        with patch("ffmpeg_wrap._textio.sys.stderr", fake_stderr):
+            pump = TeePump("utf-8", tail_limit=10)
+            pump.feed(b"aaaaa")
+            pump.feed(b"bbbbb")
+            pump.feed(b"ccccc")
+        tail = pump.tail_bytes()
+        # Bounded: total retained never grossly exceeds the limit; always keeps
+        # the most recent chunk (mirrors the former deque logic: pop while
+        # len > limit and more than one chunk remains).
+        assert tail.endswith(b"ccccc")
+        assert len(tail) <= 15  # at most limit + last chunk size
+
+    def test_tail_matches_former_inline_logic(self):
+        # Reproduce the old inline deque bookkeeping and assert equivalence.
+        limit = 12
+        chunks = [b"123", b"4567", b"89ab", b"cdef"]
+        tail: collections.deque[bytes] = collections.deque()
+        tail_len = 0
+        for chunk in chunks:
+            tail.append(chunk)
+            tail_len += len(chunk)
+            while tail_len > limit and len(tail) > 1:
+                tail_len -= len(tail.popleft())
+        expected = b"".join(tail)
+
+        fake_stderr = MagicMock()
+        with patch("ffmpeg_wrap._textio.sys.stderr", fake_stderr):
+            pump = TeePump("utf-8", tail_limit=limit)
+            for chunk in chunks:
+                pump.feed(chunk)
+        assert pump.tail_bytes() == expected
+
+    def test_feed_swallows_sink_write_errors(self):
+        fake_stderr = MagicMock()
+        fake_stderr.buffer.write.side_effect = OSError("pipe closed")
+        with patch("ffmpeg_wrap._textio.sys.stderr", fake_stderr):
+            pump = TeePump("utf-8")
+            pump.feed(b"data")  # must not raise
+        # Tail still retained even when the live write failed.
+        assert pump.tail_bytes() == b"data"
+
+
+class TestProbeBuildersAndParse:
+    def test_build_probe_cmd_shape(self):
+        cmd = _build_probe_cmd("in.mkv", "ffprobe")
+        assert cmd[0] == "ffprobe"
+        assert cmd[1:7] == ["-v", "quiet", "-print_format", "json", "-show_format", "-show_streams"]
+        assert cmd[-1].endswith("in.mkv")
+
+    def test_parse_probe_output_assigns_type_indices(self):
+        data = (
+            b'{"streams": [{"index": 0, "codec_type": "video"}, '
+            b'{"index": 1, "codec_type": "audio"}, '
+            b'{"index": 2, "codec_type": "audio"}]}'
+        )
+        result = _parse_probe_output(data, ["ffprobe"])
+        assert [s.type_index for s in result.streams] == [0, 0, 1]
+
+    def test_parse_probe_output_raises_ffmpegerror_on_bad_json(self):
+        with pytest.raises(FFmpegError) as exc:
+            _parse_probe_output(b"not json", ["ffprobe", "x"])
+        assert "ffprobe output parsing error" in str(exc.value)
+        assert exc.value.cmd == ["ffprobe", "x"]
+
+    def test_build_validate_cmd_loglevel_precondition(self):
+        with pytest.raises(ValueError, match="invalid loglevel"):
+            _build_validate_cmd("in.mkv", loglevel="nope")
+
+    def test_build_validate_cmd_shape(self):
+        cmd = _build_validate_cmd("in.mkv", "ffprobe", "warning", ("-show_format",))
+        assert cmd[:4] == ["ffprobe", "-v", "warning", "-show_format"]
+        assert cmd[-1].endswith("in.mkv")
+
+    def test_interpret_validate_ok(self):
+        assert _interpret_validate(0, b"") == (True, "")
+        assert _interpret_validate(0, b"   ") == (True, "   ")
+
+    def test_interpret_validate_not_ok(self):
+        ok, text = _interpret_validate(1, b"boom")
+        assert ok is False
+        assert text == "boom"
+        ok2, _ = _interpret_validate(0, b"warning: dts")
+        assert ok2 is False
+
+
+class TestEncodersBuilder:
+    def test_build_encoders_cmd(self):
+        assert _build_encoders_cmd("ffmpeg") == ["ffmpeg", "-hide_banner", "-encoders"]
+        assert _build_encoders_cmd("/usr/bin/ffmpeg")[0] == "/usr/bin/ffmpeg"
+
+
+class TestSyncErrorParity:
+    """The sync failure paths must still build identical FFmpegError objects."""
+
+    @patch("ffmpeg_wrap._builder.subprocess.Popen")
+    def test_run_tee_failure_error_unchanged(self, mock_popen):
+        process = MagicMock()
+        process.stderr = MagicMock()
+        process.stderr.read1.side_effect = [b"boom stderr", b""]
+        process.stdout = None
+        process.returncode = 3
+        cm = MagicMock()
+        cm.__enter__.return_value = process
+        cm.__exit__.return_value = False
+        mock_popen.return_value = cm
+        ff = FFmpeg().input("in.mkv").output("out.mp4")
+        with patch("ffmpeg_wrap._builder.sys.stderr", MagicMock()), pytest.raises(FFmpegError) as exc:
+            ff.run()
+        err = exc.value
+        assert err.returncode == 3
+        assert err.cmd == ["ffmpeg", "-i", "in.mkv", "out.mp4"]
+        # The run() catch decodes the byte stderr from the tee (text=False).
+        assert err.stderr == "boom stderr"
+        assert str(err) == "ffmpeg error: boom stderr"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_probe_called_process_error_unchanged(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["ffprobe"], stderr=b"bad media")
+        with pytest.raises(FFmpegError) as exc:
+            probe("in.mkv")
+        err = exc.value
+        assert err.stderr == "bad media"
+        assert err.returncode == 1
+        assert str(err) == "ffprobe error: bad media"
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_probe_oserror_unchanged(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("no ffprobe")
+        with pytest.raises(FFmpegError) as exc:
+            probe("in.mkv")
+        assert exc.value.returncode is None
+        assert exc.value.stderr is None
+        assert "ffprobe could not be executed" in str(exc.value)
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_oserror_unchanged(self, mock_run):
+        mock_run.side_effect = OSError("boom")
+        with pytest.raises(FFmpegError) as exc:
+            validate("in.mkv")
+        assert "ffprobe could not be executed" in str(exc.value)
+
+    @patch("ffmpeg_wrap._probe.subprocess.run")
+    def test_validate_success_path(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+        assert validate("in.mkv") == (True, "")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,205 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "anyio"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -25,22 +224,79 @@ wheels = [
 
 [[package]]
 name = "ffmpeg-wrap"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "msgspec" },
 ]
 
+[package.optional-dependencies]
+async = [
+    { name = "anyio" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "trio" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "msgspec", specifier = ">=0.21.0" }]
+requires-dist = [
+    { name = "anyio", marker = "extra == 'async'", specifier = ">=4.0" },
+    { name = "msgspec", specifier = ">=0.21.0" },
+]
+provides-extras = ["async"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.0" }]
+dev = [
+    { name = "anyio", specifier = ">=4.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
+    { name = "trio", specifier = ">=0.25" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -49,6 +305,241 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
 ]
 
 [[package]]
@@ -108,12 +599,51 @@ wheels = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -126,12 +656,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]
@@ -150,6 +702,148 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -207,10 +901,69 @@ wheels = [
 ]
 
 [[package]]
+name = "trio"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
## Overview

Adds a fully asynchronous mirror of the sync API under `ffmpeg_wrap.aio`, so callers can drive many ffmpeg/ffprobe jobs concurrently without blocking the event loop. It is powered by [AnyIO](https://anyio.readthedocs.io/), so the same code runs on both the asyncio and trio backends — the caller picks the backend.

`anyio` is an optional extra (`uv add "ffmpeg-wrap[async]"` / `pip install "ffmpeg-wrap[async]"`). The core stays dependency-light: `import ffmpeg_wrap` — and `from ffmpeg_wrap import *` — never import anyio.

## What's new

- `aio.run` / `aio.probe` / `aio.validate` / `aio.encoders` / `aio.has_encoder`, plus `FFmpeg.arun()` for the fluent form: `await input(...).output(...).arun()`.
- Thread-free tee: live stderr forwarding runs in an AnyIO task group instead of the sync path's per-run OS pump thread. On trio there is no per-process child-reaping thread (the asyncio threaded child watcher spawns one per subprocess on the non-pidfd path).
- The `aio` submodule is exposed lazily via a PEP 562 `__getattr__`, so the optional dependency is only imported on first use.

## Design

Functional core / imperative shell: command building, output parsing, decoding, error construction, and the bounded-tail tee (`TeePump`) each live in one place and are shared by the sync and async paths. The only sync/async-specific code is the I/O call (`subprocess.*` vs `anyio.*`) and the read loop. The existing sync functions were refactored onto these shared helpers, so the shared core is covered by the pre-existing test suite rather than being a parallel reimplementation.

Sync/async `FFmpegError` parity is byte-for-byte on the `text=False` path (`stderr`, `returncode`, `cmd`, and `str(e)`). On `text=True` the async capture path decodes leniently (`errors="replace"`) where the sync path uses subprocess's strict decode — intentional and documented.

Internal imports were also switched from relative to absolute for consistency.

## Tests

Backend-parametrized over asyncio and trio: success/error, sync/async parity, no per-process reaping thread on trio (plus a bounded worker-pool check), concurrent-read deadlock, mid-read cancellation, `sys.stderr.buffer is None` fallback, `CapacityLimiter` highload, and import isolation (`import ffmpeg_wrap` and `from ffmpeg_wrap import *` stay anyio-free). The suite passes on both backends and also passes without the `[async]` extra installed (the async modules skip cleanly). CI gained import smoke-tests for both the anyio-free core and the `[async]` extra.

## Documentation

A MkDocs Material + mkdocstrings site with an auto-generated API reference built from the Google-style docstrings, with a usage example on every public symbol. The README is trimmed to a sync and an async quick-start plus a pointer to the site. A GitHub Pages workflow builds and deploys the docs.

Bumps the version to 0.4.0.
